### PR TITLE
feature: AD-36 - setup PaC for quality dashboard

### DIFF
--- a/.tekton/pull-request-backend.yaml
+++ b/.tekton/pull-request-backend.yaml
@@ -1,0 +1,30 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: dashboard-backend-on-pull-request
+  annotations:
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" && target_branch == "main" && "backend/***".pathChanged()
+    pipelinesascode.tekton.dev/max-keep-runs: "2"
+spec:
+  params:
+    - name: git-url
+      value: "{{repo_url}}"
+    - name: revision
+      value: "{{revision}}"
+    - name: output-image
+      value: "quay.io/redhat-appstudio/pull-request-builds:quality-dashboard-backend-{{revision}}"
+    - name: path-context
+      value: "backend"
+  pipelineRef:
+    name: docker-build
+    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/.tekton/pull-request-frontend.yaml
+++ b/.tekton/pull-request-frontend.yaml
@@ -1,0 +1,30 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: dashboard-frontend-on-pull-request
+  annotations:
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" && target_branch == "main" && "frontend/***".pathChanged()
+    pipelinesascode.tekton.dev/max-keep-runs: "2"
+spec:
+  params:
+    - name: git-url
+      value: "{{repo_url}}"
+    - name: revision
+      value: "{{revision}}"
+    - name: output-image
+      value: "quay.io/redhat-appstudio/pull-request-builds:quality-dashboard-frontend-{{revision}}"
+    - name: path-context
+      value: "frontend"
+  pipelineRef:
+    name: docker-build
+    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/.tekton/push-backend.yaml
+++ b/.tekton/push-backend.yaml
@@ -1,0 +1,33 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: dashboard-backend-on-push
+  annotations:
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "refs/heads/main" && "backend/***".pathChanged()
+    pipelinesascode.tekton.dev/max-keep-runs: "2"
+spec:
+  params:
+    - name: git-url
+      value: "{{repo_url}}"
+    - name: revision
+      value: "{{revision}}"
+    - name: output-image
+      value: "quay.io/redhat-appstudio/quality-dashboard-backend:{{revision}}"
+    - name: path-context
+      value: "backend"
+    - name: infra-deployment-update-script
+      value: |
+        sed -i -e 's|\(https://github.com/redhat-appstudio/quality-dashboard/backend/deploy/base?ref=\).*|\1{{ revision }}|' -e 's|\(newTag: \).*|\1{{ revision }}|' components/quality-dashboard/backend/kustomization.yaml
+  pipelineRef:
+    name: docker-build
+    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/.tekton/push-frontend.yaml
+++ b/.tekton/push-frontend.yaml
@@ -1,0 +1,33 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: dashboard-frontend-on-push
+  annotations:
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "refs/heads/main" && "frontend/***".pathChanged()
+    pipelinesascode.tekton.dev/max-keep-runs: "2"
+spec:
+  params:
+    - name: git-url
+      value: "{{repo_url}}"
+    - name: revision
+      value: "{{revision}}"
+    - name: output-image
+      value: "quay.io/redhat-appstudio/quality-dashboard-frontend:{{revision}}"
+    - name: path-context
+      value: "frontend"
+    - name: infra-deployment-update-script
+      value: |
+        sed -i -e 's|\(https://github.com/redhat-appstudio/quality-dashboard/frontend/deploy/base?ref=\).*|\1{{ revision }}|' -e 's|\(newTag: \).*|\1{{ revision }}|' components/quality-dashboard/frontend/kustomization.yaml
+  pipelineRef:
+    name: docker-build
+    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi


### PR DESCRIPTION
This PR creates 4 PaC Pipelines
- dashboard-backend-on-pull-request
  - Builds backend image and pushes it to `quay.io/redhat-appstudio/pull-request-builds` as it's usual with other services
- dashboard-backend-on-pull-request
  - Builds frontend image and pushes it to `quay.io/redhat-appstudio/pull-request-builds`
- dashboard-backend-on-push
  - Runs on merge to `main` branch
  - Builds the image
  - Publishes it in quay.io/redhat-appstudio/quality-dashboard-backend
  - Creates PR in `infra-deployments` repo with latest changes
 - dashboard-frontend-on-push
  - Runs on merge to `main` branch
  - Builds the image
  - Publishes it in quay.io/redhat-appstudio/quality-dashboard-frontend
  - Creates PR in `infra-deployments` repo with latest changes
 
I've tested this PR just partially as it is really hard to setup whole environment. So I've just deployed my Appstudio instance with my own PaC Github App and my own repository. This is the result of creation & merge of 2 PRs - one containing change in `backend` and one in `frontend` folders:
![image](https://user-images.githubusercontent.com/1215011/205335083-8eb79a1d-7550-4542-9447-3ff3c9ee034a.png)

(The failed task is push of the image - as it is trying to push to the redhat-appstudio quay org and it doesn't have the rights to do so)

Note: The `sed` commands for updating SHAs in infra-deployments were tested locally:
```
$ sed  -e 's|\(https://github.com/redhat-appstudio/quality-dashboard/backend/deploy/base?ref=\).*|\1{{ revision }}|' -e 's|\(newTag: \).*|\1{{ revision }}|' components/quality-dashboard/backend/kustomization.yaml
resources:
- https://github.com/redhat-appstudio/quality-dashboard/backend/deploy/base?ref={{ revision }}

apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization


images:
  - name: quay.io/redhat-appstudio/quality-dashboard-backend
    newName: quay.io/redhat-appstudio/quality-dashboard-backend
    newTag: {{ revision }}

$ sed -e 's|\(https://github.com/redhat-appstudio/quality-dashboard/frontend/deploy/base?ref=\).*|\1{{ revision }}|' -e 's|\(newTag: \).*|\1{{ revision }}|' components/quality-dashboard/frontend/kustomization.yaml 
resources:
- https://github.com/redhat-appstudio/quality-dashboard/frontend/deploy/base?ref={{ revision }}

apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

configMapGenerator:
- name: quality-dashboard-configmap
  literals:
  - BACKEND_ROUTE=https://quality-backend-route-quality-dashboard.apps.appstudio-stage.x99m.p1.openshiftapps.com

images:
  - name: quay.io/redhat-appstudio/quality-dashboard-frontend
    newName: quay.io/redhat-appstudio/quality-dashboard-frontend
    newTag: {{ revision }}
```
