### PR TITLE
🐛 fix target_branch in PaC

### DIFF
--- a/.tekton/push-backend.yaml
+++ b/.tekton/push-backend.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dashboard-backend-on-push
   annotations:
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "refs/heads/main" && "backend/***".pathChanged()
+      event == "push" && target_branch == "*main" && "backend/***".pathChanged()
     pipelinesascode.tekton.dev/max-keep-runs: "2"
 spec:
   params:

--- a/.tekton/push-frontend.yaml
+++ b/.tekton/push-frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dashboard-frontend-on-push
   annotations:
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "refs/heads/main" && "frontend/***".pathChanged()
+      event == "push" && target_branch == "*main" && "frontend/***".pathChanged()
     pipelinesascode.tekton.dev/max-keep-runs: "2"
 spec:
   params:


### PR DESCRIPTION
We have to have target branch configured to `refs/heads/main` in order for the push PipelineRun to be started, but then it doesn't work with Re-Run button for rerunning the pipeline. 
I've registered https://issues.redhat.com/browse/SRVKP-2692 bug with PaC, but in the meantime I was suggested to use `*main` instead (https://coreos.slack.com/archives/C0382KN768J/p1671027909826279?thread_ts=1671027265.427709&cid=C0382KN768J)

Signed-off-by: Radim Hopp <rhopp@redhat.com>