### PR TITLE
🐛 Fix local frontend deployment

### DIFF
--- a/.tekton/pull-request-frontend.yaml
+++ b/.tekton/pull-request-frontend.yaml
@@ -16,6 +16,8 @@ spec:
       value: "quay.io/redhat-appstudio/pull-request-builds:quality-dashboard-frontend-{{revision}}"
     - name: path-context
       value: "frontend"
+    - name: dockerfile
+      value: "frontend/build/Dockerfile"
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest

--- a/.tekton/push-frontend.yaml
+++ b/.tekton/push-frontend.yaml
@@ -16,6 +16,8 @@ spec:
       value: "quay.io/redhat-appstudio/quality-dashboard-frontend:{{revision}}"
     - name: path-context
       value: "frontend"
+    - name: dockerfile
+      value: "frontend/build/Dockerfile"
     - name: infra-deployment-update-script
       value: |
         sed -i -e 's|\(https://github.com/redhat-appstudio/quality-dashboard/frontend/deploy/base?ref=\).*|\1{{ revision }}|' -e 's|\(newTag: \).*|\1{{ revision }}|' components/quality-dashboard/frontend/kustomization.yaml

--- a/frontend/deploy/overlays/local/kustomization.yaml
+++ b/frontend/deploy/overlays/local/kustomization.yaml
@@ -8,7 +8,6 @@ namespace: appstudio-qe
 
 configMapGenerator:
 - name: quality-dashboard-configmap
-  behavior: replace
   envs:
   - configmap.txt
 


### PR DESCRIPTION
Before this change, local deployment (using kustomize directly, or by running `./hack/install.sh`) failed with
```
Error: merging from generator &{0xc001a84000 {  map[] map[]} {{ quality-dashboard-configmap replace {[] [] [configmap.txt] } <nil>}}}: id resid.ResId{Gvk:resid.Gvk{Group:"", Version:"v1", Kind:"ConfigMap", isClusterScoped:false}, Name:"quality-dashboard-configmap", Namespace:""} does not exist; cannot merge or replace
```
This is probably overlook of when I had also configmap in base layer in this repo... but that configmap was finally moved to infra-deployments.

Signed-off-by: Radim Hopp <rhopp@redhat.com>