### PR TITLE
🐛 AD-36 fix of push pipelines after SRVKP-2692 fix

### DIFF
--- a/.tekton/push-backend.yaml
+++ b/.tekton/push-backend.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dashboard-backend-on-push
   annotations:
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "*main" && "backend/***".pathChanged()
+      event == "push" && target_branch == "main" && "backend/***".pathChanged()
     pipelinesascode.tekton.dev/max-keep-runs: "2"
 spec:
   params:

--- a/.tekton/push-frontend.yaml
+++ b/.tekton/push-frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dashboard-frontend-on-push
   annotations:
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "*main" && "frontend/***".pathChanged()
+      event == "push" && target_branch == "main" && "frontend/***".pathChanged()
     pipelinesascode.tekton.dev/max-keep-runs: "2"
 spec:
   params:


### PR DESCRIPTION
Since PaC 1.5.0 is already installed on staged cluster  and [PaC 1.5.0](https://github.com/openshift-pipelines/pipelines-as-code/releases/tag/v0.15.0) contains fix for [SRVKP-2692](https://issues.redhat.com/browse/SRVKP-2692), this change should solve our "problems" ;-)

Signed-off-by: Radim Hopp <rhopp@redhat.com>