### PR TITLE
AD-59: Add link to the job history

### DIFF
--- a/frontend/src/app/Reports/Reports.tsx
+++ b/frontend/src/app/Reports/Reports.tsx
@@ -282,9 +282,10 @@ let Reports = () => {
     }
   }
 
-  // Extract a simple list of jobs from data: this will be used to let users select the job they want to see details for
-  let jobNames: SimpleListData[] = prowJobsStats?.jobs != null ? prowJobsStats.jobs.map(function (job, index) { return { "value": job.name + " (Total: " + job.summary.total_jobs + ")", "index": index } }) : []
   let ci_html: string = prowJobsStats?.jobs != null ? "https://prow.ci.openshift.org/?repo=" + prowJobsStats?.git_organization + "%2F" + prowJobsStats?.repository_name + "&type=" + prowJobsStats?.type : ''
+
+  // Extract a simple list of jobs from data: this will be used to let users select the job they want to see details for
+  let jobNames: SimpleListData[] = prowJobsStats?.jobs != null ? prowJobsStats.jobs.map(function (job, index) { return { "value": job.name + " (Total: " + job.summary.total_jobs + ")", "index": index, "href": ci_html + "&job=" + job.name } }) : []
 
   // Prepare data for the line chart
   let beautifiedData: DashboardLineChartData = {
@@ -479,12 +480,12 @@ let Reports = () => {
               </Select>
             </ToolbarItem>
             <ToolbarItem style={{ minWidth: "fitContent", maxWidth: "fitContent" }}>
-                <DateTimeRangePicker
-                  startDate={start}
-                  endDate={end}
-                  handleChange={(event, from, to) => handleChange(event, from, to)}
-                >
-                </DateTimeRangePicker>
+              <DateTimeRangePicker
+                startDate={start}
+                endDate={end}
+                handleChange={(event, from, to) => handleChange(event, from, to)}
+              >
+              </DateTimeRangePicker>
             </ToolbarItem>
             <ToolbarItem style={{ minWidth: "fitContent", maxWidth: "fitContent" }}>
               <Button variant="link" onClick={clearParams}>Clear</Button>

--- a/frontend/src/app/utils/sharedComponents.tsx
+++ b/frontend/src/app/utils/sharedComponents.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useLayoutEffect, useRef } from 'react';
-import { ExclamationCircleIcon, OkIcon, HelpIcon } from '@patternfly/react-icons';
-import { Card, CardTitle, CardBody } from '@patternfly/react-core';
+import { ExclamationCircleIcon, OkIcon, HelpIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { Card, CardTitle, CardBody, Badge } from '@patternfly/react-core';
 import { Chart, ChartAxis, ChartLine, ChartGroup, ChartVoronoiContainer, ChartLegend } from '@patternfly/react-charts';
 import { SimpleList, SimpleListItem } from '@patternfly/react-core';
 
@@ -51,15 +51,27 @@ export type SimpleListProps = {
 
 export type SimpleListData = {
   index: number;
-  value: string;
+  value: any;
+  href: string;
 };
+
+const getSimpleListItem = (job) => {
+  return <div>{job.value}
+    <a href={job.href} target="blank" rel="noopener noreferrer">
+      <Badge style={{ marginLeft: 5 }}><ExternalLinkAltIcon></ExternalLinkAltIcon>
+      </Badge>
+    </a>
+  </div>
+}
 
 export const DashboardSimpleList = ({ data, onSelection, title }: SimpleListProps) => {
   const onSelect = (selectedItem, selectedItemProps) => {
     onSelection(selectedItemProps["data-index"])
   }
 
-  const items = data.map((job) => <SimpleListItem className="" key={job.index} data-index={job.index} isActive={job.index == 0}> {job.value} </SimpleListItem>);
+  const items = data.map((job) => <SimpleListItem className="" key={job.index} data-index={job.index} isActive={job.index == 0}> {
+    getSimpleListItem(job)
+  } </SimpleListItem>);
 
   return (
     <Card style={{ width: "100%", height: "100%", fontSize: "1rem" }}>


### PR DESCRIPTION
# Description
- Add link to the job history

# 🚨 To take into consideration
There is a limitation of 12h for the links. Both global link (https://prow.ci.openshift.org/?repo=redhat-appstudio%2Finfra-deployments&type=periodic) and specific job link (https://prow.ci.openshift.org/?repo=redhat-appstudio%2Finfra-deployments&type=periodic&job=periodic-ci-redhat-appstudio-infra-deployments-main-hacbs-e2e-periodic) will present job history regarding the last 12h. So, the number of total jobs will be different for the jobs that appear in the link. 

## Issue ticket number and link
[AD-59](https://issues.redhat.com/browse/AD-59)