### PR TITLE
AD-77 and AD-78: populate "Chosen options" + include the Jira project key in the list of projects

### DIFF
--- a/backend/pkg/storage/ent/client/types.go
+++ b/backend/pkg/storage/ent/client/types.go
@@ -42,13 +42,3 @@ func toStorageRepositoryAllInfo(p *db.Repository, c *db.CodeCov) storage.Reposit
 		},
 	}
 }
-
-func toStoragePrs(pr *db.PullRequests) repoV1Alpha1.PullRequest {
-	return repoV1Alpha1.PullRequest{
-		Title:     pr.Title,
-		CreatedAt: pr.CreatedAt,
-		MergedAt:  pr.MergedAt,
-		ClosedAt:  pr.ClosedAt,
-		State:     pr.State,
-	}
-}

--- a/backend/pkg/storage/ent/db/bugs.go
+++ b/backend/pkg/storage/ent/db/bugs.go
@@ -38,6 +38,8 @@ type Bugs struct {
 	Summary string `json:"summary,omitempty"`
 	// URL holds the value of the "url" field.
 	URL string `json:"url,omitempty"`
+	// ProjectKey holds the value of the "project_key" field.
+	ProjectKey *string `json:"project_key,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the BugsQuery when eager-loading is set.
 	Edges      BugsEdges `json:"edges"`
@@ -75,7 +77,7 @@ func (*Bugs) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullBool)
 		case bugs.FieldResolutionTime:
 			values[i] = new(sql.NullFloat64)
-		case bugs.FieldJiraKey, bugs.FieldPriority, bugs.FieldStatus, bugs.FieldSummary, bugs.FieldURL:
+		case bugs.FieldJiraKey, bugs.FieldPriority, bugs.FieldStatus, bugs.FieldSummary, bugs.FieldURL, bugs.FieldProjectKey:
 			values[i] = new(sql.NullString)
 		case bugs.FieldCreatedAt, bugs.FieldUpdatedAt, bugs.FieldResolvedAt:
 			values[i] = new(sql.NullTime)
@@ -165,6 +167,13 @@ func (b *Bugs) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				b.URL = value.String
 			}
+		case bugs.FieldProjectKey:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field project_key", values[i])
+			} else if value.Valid {
+				b.ProjectKey = new(string)
+				*b.ProjectKey = value.String
+			}
 		case bugs.ForeignKeys[0]:
 			if value, ok := values[i].(*sql.NullScanner); !ok {
 				return fmt.Errorf("unexpected type %T for field teams_bugs", values[i])
@@ -236,6 +245,11 @@ func (b *Bugs) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("url=")
 	builder.WriteString(b.URL)
+	builder.WriteString(", ")
+	if v := b.ProjectKey; v != nil {
+		builder.WriteString("project_key=")
+		builder.WriteString(*v)
+	}
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/backend/pkg/storage/ent/db/bugs/bugs.go
+++ b/backend/pkg/storage/ent/db/bugs/bugs.go
@@ -31,6 +31,8 @@ const (
 	FieldSummary = "summary"
 	// FieldURL holds the string denoting the url field in the database.
 	FieldURL = "url"
+	// FieldProjectKey holds the string denoting the project_key field in the database.
+	FieldProjectKey = "project_key"
 	// EdgeBugs holds the string denoting the bugs edge name in mutations.
 	EdgeBugs = "bugs"
 	// TeamsFieldID holds the string denoting the ID field of the Teams.
@@ -59,6 +61,7 @@ var Columns = []string{
 	FieldStatus,
 	FieldSummary,
 	FieldURL,
+	FieldProjectKey,
 }
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the "bugs"

--- a/backend/pkg/storage/ent/db/bugs/where.go
+++ b/backend/pkg/storage/ent/db/bugs/where.go
@@ -106,6 +106,11 @@ func URL(v string) predicate.Bugs {
 	return predicate.Bugs(sql.FieldEQ(FieldURL, v))
 }
 
+// ProjectKey applies equality check predicate on the "project_key" field. It's identical to ProjectKeyEQ.
+func ProjectKey(v string) predicate.Bugs {
+	return predicate.Bugs(sql.FieldEQ(FieldProjectKey, v))
+}
+
 // JiraKeyEQ applies the EQ predicate on the "jira_key" field.
 func JiraKeyEQ(v string) predicate.Bugs {
 	return predicate.Bugs(sql.FieldEQ(FieldJiraKey, v))
@@ -599,6 +604,81 @@ func URLEqualFold(v string) predicate.Bugs {
 // URLContainsFold applies the ContainsFold predicate on the "url" field.
 func URLContainsFold(v string) predicate.Bugs {
 	return predicate.Bugs(sql.FieldContainsFold(FieldURL, v))
+}
+
+// ProjectKeyEQ applies the EQ predicate on the "project_key" field.
+func ProjectKeyEQ(v string) predicate.Bugs {
+	return predicate.Bugs(sql.FieldEQ(FieldProjectKey, v))
+}
+
+// ProjectKeyNEQ applies the NEQ predicate on the "project_key" field.
+func ProjectKeyNEQ(v string) predicate.Bugs {
+	return predicate.Bugs(sql.FieldNEQ(FieldProjectKey, v))
+}
+
+// ProjectKeyIn applies the In predicate on the "project_key" field.
+func ProjectKeyIn(vs ...string) predicate.Bugs {
+	return predicate.Bugs(sql.FieldIn(FieldProjectKey, vs...))
+}
+
+// ProjectKeyNotIn applies the NotIn predicate on the "project_key" field.
+func ProjectKeyNotIn(vs ...string) predicate.Bugs {
+	return predicate.Bugs(sql.FieldNotIn(FieldProjectKey, vs...))
+}
+
+// ProjectKeyGT applies the GT predicate on the "project_key" field.
+func ProjectKeyGT(v string) predicate.Bugs {
+	return predicate.Bugs(sql.FieldGT(FieldProjectKey, v))
+}
+
+// ProjectKeyGTE applies the GTE predicate on the "project_key" field.
+func ProjectKeyGTE(v string) predicate.Bugs {
+	return predicate.Bugs(sql.FieldGTE(FieldProjectKey, v))
+}
+
+// ProjectKeyLT applies the LT predicate on the "project_key" field.
+func ProjectKeyLT(v string) predicate.Bugs {
+	return predicate.Bugs(sql.FieldLT(FieldProjectKey, v))
+}
+
+// ProjectKeyLTE applies the LTE predicate on the "project_key" field.
+func ProjectKeyLTE(v string) predicate.Bugs {
+	return predicate.Bugs(sql.FieldLTE(FieldProjectKey, v))
+}
+
+// ProjectKeyContains applies the Contains predicate on the "project_key" field.
+func ProjectKeyContains(v string) predicate.Bugs {
+	return predicate.Bugs(sql.FieldContains(FieldProjectKey, v))
+}
+
+// ProjectKeyHasPrefix applies the HasPrefix predicate on the "project_key" field.
+func ProjectKeyHasPrefix(v string) predicate.Bugs {
+	return predicate.Bugs(sql.FieldHasPrefix(FieldProjectKey, v))
+}
+
+// ProjectKeyHasSuffix applies the HasSuffix predicate on the "project_key" field.
+func ProjectKeyHasSuffix(v string) predicate.Bugs {
+	return predicate.Bugs(sql.FieldHasSuffix(FieldProjectKey, v))
+}
+
+// ProjectKeyIsNil applies the IsNil predicate on the "project_key" field.
+func ProjectKeyIsNil() predicate.Bugs {
+	return predicate.Bugs(sql.FieldIsNull(FieldProjectKey))
+}
+
+// ProjectKeyNotNil applies the NotNil predicate on the "project_key" field.
+func ProjectKeyNotNil() predicate.Bugs {
+	return predicate.Bugs(sql.FieldNotNull(FieldProjectKey))
+}
+
+// ProjectKeyEqualFold applies the EqualFold predicate on the "project_key" field.
+func ProjectKeyEqualFold(v string) predicate.Bugs {
+	return predicate.Bugs(sql.FieldEqualFold(FieldProjectKey, v))
+}
+
+// ProjectKeyContainsFold applies the ContainsFold predicate on the "project_key" field.
+func ProjectKeyContainsFold(v string) predicate.Bugs {
+	return predicate.Bugs(sql.FieldContainsFold(FieldProjectKey, v))
 }
 
 // HasBugs applies the HasEdge predicate on the "bugs" edge.

--- a/backend/pkg/storage/ent/db/bugs_create.go
+++ b/backend/pkg/storage/ent/db/bugs_create.go
@@ -101,6 +101,20 @@ func (bc *BugsCreate) SetURL(s string) *BugsCreate {
 	return bc
 }
 
+// SetProjectKey sets the "project_key" field.
+func (bc *BugsCreate) SetProjectKey(s string) *BugsCreate {
+	bc.mutation.SetProjectKey(s)
+	return bc
+}
+
+// SetNillableProjectKey sets the "project_key" field if the given value is not nil.
+func (bc *BugsCreate) SetNillableProjectKey(s *string) *BugsCreate {
+	if s != nil {
+		bc.SetProjectKey(*s)
+	}
+	return bc
+}
+
 // SetID sets the "id" field.
 func (bc *BugsCreate) SetID(u uuid.UUID) *BugsCreate {
 	bc.mutation.SetID(u)
@@ -302,6 +316,10 @@ func (bc *BugsCreate) createSpec() (*Bugs, *sqlgraph.CreateSpec) {
 		_spec.SetField(bugs.FieldURL, field.TypeString, value)
 		_node.URL = value
 	}
+	if value, ok := bc.mutation.ProjectKey(); ok {
+		_spec.SetField(bugs.FieldProjectKey, field.TypeString, value)
+		_node.ProjectKey = &value
+	}
 	if nodes := bc.mutation.BugsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -502,6 +520,24 @@ func (u *BugsUpsert) UpdateURL() *BugsUpsert {
 	return u
 }
 
+// SetProjectKey sets the "project_key" field.
+func (u *BugsUpsert) SetProjectKey(v string) *BugsUpsert {
+	u.Set(bugs.FieldProjectKey, v)
+	return u
+}
+
+// UpdateProjectKey sets the "project_key" field to the value that was provided on create.
+func (u *BugsUpsert) UpdateProjectKey() *BugsUpsert {
+	u.SetExcluded(bugs.FieldProjectKey)
+	return u
+}
+
+// ClearProjectKey clears the value of the "project_key" field.
+func (u *BugsUpsert) ClearProjectKey() *BugsUpsert {
+	u.SetNull(bugs.FieldProjectKey)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -696,6 +732,27 @@ func (u *BugsUpsertOne) SetURL(v string) *BugsUpsertOne {
 func (u *BugsUpsertOne) UpdateURL() *BugsUpsertOne {
 	return u.Update(func(s *BugsUpsert) {
 		s.UpdateURL()
+	})
+}
+
+// SetProjectKey sets the "project_key" field.
+func (u *BugsUpsertOne) SetProjectKey(v string) *BugsUpsertOne {
+	return u.Update(func(s *BugsUpsert) {
+		s.SetProjectKey(v)
+	})
+}
+
+// UpdateProjectKey sets the "project_key" field to the value that was provided on create.
+func (u *BugsUpsertOne) UpdateProjectKey() *BugsUpsertOne {
+	return u.Update(func(s *BugsUpsert) {
+		s.UpdateProjectKey()
+	})
+}
+
+// ClearProjectKey clears the value of the "project_key" field.
+func (u *BugsUpsertOne) ClearProjectKey() *BugsUpsertOne {
+	return u.Update(func(s *BugsUpsert) {
+		s.ClearProjectKey()
 	})
 }
 
@@ -1058,6 +1115,27 @@ func (u *BugsUpsertBulk) SetURL(v string) *BugsUpsertBulk {
 func (u *BugsUpsertBulk) UpdateURL() *BugsUpsertBulk {
 	return u.Update(func(s *BugsUpsert) {
 		s.UpdateURL()
+	})
+}
+
+// SetProjectKey sets the "project_key" field.
+func (u *BugsUpsertBulk) SetProjectKey(v string) *BugsUpsertBulk {
+	return u.Update(func(s *BugsUpsert) {
+		s.SetProjectKey(v)
+	})
+}
+
+// UpdateProjectKey sets the "project_key" field to the value that was provided on create.
+func (u *BugsUpsertBulk) UpdateProjectKey() *BugsUpsertBulk {
+	return u.Update(func(s *BugsUpsert) {
+		s.UpdateProjectKey()
+	})
+}
+
+// ClearProjectKey clears the value of the "project_key" field.
+func (u *BugsUpsertBulk) ClearProjectKey() *BugsUpsertBulk {
+	return u.Update(func(s *BugsUpsert) {
+		s.ClearProjectKey()
 	})
 }
 

--- a/backend/pkg/storage/ent/db/bugs_update.go
+++ b/backend/pkg/storage/ent/db/bugs_update.go
@@ -113,6 +113,26 @@ func (bu *BugsUpdate) SetURL(s string) *BugsUpdate {
 	return bu
 }
 
+// SetProjectKey sets the "project_key" field.
+func (bu *BugsUpdate) SetProjectKey(s string) *BugsUpdate {
+	bu.mutation.SetProjectKey(s)
+	return bu
+}
+
+// SetNillableProjectKey sets the "project_key" field if the given value is not nil.
+func (bu *BugsUpdate) SetNillableProjectKey(s *string) *BugsUpdate {
+	if s != nil {
+		bu.SetProjectKey(*s)
+	}
+	return bu
+}
+
+// ClearProjectKey clears the value of the "project_key" field.
+func (bu *BugsUpdate) ClearProjectKey() *BugsUpdate {
+	bu.mutation.ClearProjectKey()
+	return bu
+}
+
 // SetBugsID sets the "bugs" edge to the Teams entity by ID.
 func (bu *BugsUpdate) SetBugsID(id uuid.UUID) *BugsUpdate {
 	bu.mutation.SetBugsID(id)
@@ -233,6 +253,12 @@ func (bu *BugsUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := bu.mutation.URL(); ok {
 		_spec.SetField(bugs.FieldURL, field.TypeString, value)
+	}
+	if value, ok := bu.mutation.ProjectKey(); ok {
+		_spec.SetField(bugs.FieldProjectKey, field.TypeString, value)
+	}
+	if bu.mutation.ProjectKeyCleared() {
+		_spec.ClearField(bugs.FieldProjectKey, field.TypeString)
 	}
 	if bu.mutation.BugsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -369,6 +395,26 @@ func (buo *BugsUpdateOne) SetSummary(s string) *BugsUpdateOne {
 // SetURL sets the "url" field.
 func (buo *BugsUpdateOne) SetURL(s string) *BugsUpdateOne {
 	buo.mutation.SetURL(s)
+	return buo
+}
+
+// SetProjectKey sets the "project_key" field.
+func (buo *BugsUpdateOne) SetProjectKey(s string) *BugsUpdateOne {
+	buo.mutation.SetProjectKey(s)
+	return buo
+}
+
+// SetNillableProjectKey sets the "project_key" field if the given value is not nil.
+func (buo *BugsUpdateOne) SetNillableProjectKey(s *string) *BugsUpdateOne {
+	if s != nil {
+		buo.SetProjectKey(*s)
+	}
+	return buo
+}
+
+// ClearProjectKey clears the value of the "project_key" field.
+func (buo *BugsUpdateOne) ClearProjectKey() *BugsUpdateOne {
+	buo.mutation.ClearProjectKey()
 	return buo
 }
 
@@ -516,6 +562,12 @@ func (buo *BugsUpdateOne) sqlSave(ctx context.Context) (_node *Bugs, err error) 
 	}
 	if value, ok := buo.mutation.URL(); ok {
 		_spec.SetField(bugs.FieldURL, field.TypeString, value)
+	}
+	if value, ok := buo.mutation.ProjectKey(); ok {
+		_spec.SetField(bugs.FieldProjectKey, field.TypeString, value)
+	}
+	if buo.mutation.ProjectKeyCleared() {
+		_spec.ClearField(bugs.FieldProjectKey, field.TypeString)
 	}
 	if buo.mutation.BugsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/backend/pkg/storage/ent/db/migrate/schema.go
+++ b/backend/pkg/storage/ent/db/migrate/schema.go
@@ -21,6 +21,7 @@ var (
 		{Name: "status", Type: field.TypeString, Size: 2147483647, SchemaType: map[string]string{"postgres": "text"}},
 		{Name: "summary", Type: field.TypeString, Size: 2147483647, SchemaType: map[string]string{"postgres": "text"}},
 		{Name: "url", Type: field.TypeString, Size: 2147483647, SchemaType: map[string]string{"postgres": "text"}},
+		{Name: "project_key", Type: field.TypeString, Nullable: true, Size: 2147483647, SchemaType: map[string]string{"postgres": "text"}},
 		{Name: "teams_bugs", Type: field.TypeUUID, Nullable: true},
 	}
 	// BugsTable holds the schema information for the "bugs" table.
@@ -31,7 +32,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "bugs_teams_bugs",
-				Columns:    []*schema.Column{BugsColumns[11]},
+				Columns:    []*schema.Column{BugsColumns[12]},
 				RefColumns: []*schema.Column{TeamsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},

--- a/backend/pkg/storage/ent/db/mutation.go
+++ b/backend/pkg/storage/ent/db/mutation.go
@@ -60,6 +60,7 @@ type BugsMutation struct {
 	status             *string
 	summary            *string
 	url                *string
+	project_key        *string
 	clearedFields      map[string]struct{}
 	bugs               *uuid.UUID
 	clearedbugs        bool
@@ -552,6 +553,55 @@ func (m *BugsMutation) ResetURL() {
 	m.url = nil
 }
 
+// SetProjectKey sets the "project_key" field.
+func (m *BugsMutation) SetProjectKey(s string) {
+	m.project_key = &s
+}
+
+// ProjectKey returns the value of the "project_key" field in the mutation.
+func (m *BugsMutation) ProjectKey() (r string, exists bool) {
+	v := m.project_key
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldProjectKey returns the old "project_key" field's value of the Bugs entity.
+// If the Bugs object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *BugsMutation) OldProjectKey(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldProjectKey is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldProjectKey requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldProjectKey: %w", err)
+	}
+	return oldValue.ProjectKey, nil
+}
+
+// ClearProjectKey clears the value of the "project_key" field.
+func (m *BugsMutation) ClearProjectKey() {
+	m.project_key = nil
+	m.clearedFields[bugs.FieldProjectKey] = struct{}{}
+}
+
+// ProjectKeyCleared returns if the "project_key" field was cleared in this mutation.
+func (m *BugsMutation) ProjectKeyCleared() bool {
+	_, ok := m.clearedFields[bugs.FieldProjectKey]
+	return ok
+}
+
+// ResetProjectKey resets all changes to the "project_key" field.
+func (m *BugsMutation) ResetProjectKey() {
+	m.project_key = nil
+	delete(m.clearedFields, bugs.FieldProjectKey)
+}
+
 // SetBugsID sets the "bugs" edge to the Teams entity by id.
 func (m *BugsMutation) SetBugsID(id uuid.UUID) {
 	m.bugs = &id
@@ -625,7 +675,7 @@ func (m *BugsMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *BugsMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 11)
 	if m.jira_key != nil {
 		fields = append(fields, bugs.FieldJiraKey)
 	}
@@ -656,6 +706,9 @@ func (m *BugsMutation) Fields() []string {
 	if m.url != nil {
 		fields = append(fields, bugs.FieldURL)
 	}
+	if m.project_key != nil {
+		fields = append(fields, bugs.FieldProjectKey)
+	}
 	return fields
 }
 
@@ -684,6 +737,8 @@ func (m *BugsMutation) Field(name string) (ent.Value, bool) {
 		return m.Summary()
 	case bugs.FieldURL:
 		return m.URL()
+	case bugs.FieldProjectKey:
+		return m.ProjectKey()
 	}
 	return nil, false
 }
@@ -713,6 +768,8 @@ func (m *BugsMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldSummary(ctx)
 	case bugs.FieldURL:
 		return m.OldURL(ctx)
+	case bugs.FieldProjectKey:
+		return m.OldProjectKey(ctx)
 	}
 	return nil, fmt.Errorf("unknown Bugs field %s", name)
 }
@@ -792,6 +849,13 @@ func (m *BugsMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetURL(v)
 		return nil
+	case bugs.FieldProjectKey:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetProjectKey(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Bugs field %s", name)
 }
@@ -836,7 +900,11 @@ func (m *BugsMutation) AddField(name string, value ent.Value) error {
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *BugsMutation) ClearedFields() []string {
-	return nil
+	var fields []string
+	if m.FieldCleared(bugs.FieldProjectKey) {
+		fields = append(fields, bugs.FieldProjectKey)
+	}
+	return fields
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -849,6 +917,11 @@ func (m *BugsMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *BugsMutation) ClearField(name string) error {
+	switch name {
+	case bugs.FieldProjectKey:
+		m.ClearProjectKey()
+		return nil
+	}
 	return fmt.Errorf("unknown Bugs nullable field %s", name)
 }
 
@@ -885,6 +958,9 @@ func (m *BugsMutation) ResetField(name string) error {
 		return nil
 	case bugs.FieldURL:
 		m.ResetURL()
+		return nil
+	case bugs.FieldProjectKey:
+		m.ResetProjectKey()
 		return nil
 	}
 	return fmt.Errorf("unknown Bugs field %s", name)

--- a/backend/pkg/storage/ent/schema/jira_bugs.go
+++ b/backend/pkg/storage/ent/schema/jira_bugs.go
@@ -42,6 +42,10 @@ func (Bugs) Fields() []ent.Field {
 			SchemaType(textSchema),
 		field.Text("url").
 			SchemaType(textSchema),
+		field.Text("project_key").
+			SchemaType(textSchema).
+			Optional().
+			Nillable(),
 	}
 }
 

--- a/backend/pkg/storage/storage.go
+++ b/backend/pkg/storage/storage.go
@@ -59,6 +59,7 @@ type Storage interface {
 	// Delete
 	DeleteRepository(repositoryName, gitOrganizationName string) error
 	DeleteTeam(teamName string) (bool, error)
+	DeleteJiraBugsByProject(projectKey string, team *db.Teams) error
 }
 
 type RepositoryQualityInfo struct {

--- a/frontend/src/app/Teams/TeamsOnboarding.tsx
+++ b/frontend/src/app/Teams/TeamsOnboarding.tsx
@@ -12,7 +12,6 @@ import { getTeams } from '@app/utils/APIService';
 import { PlusIcon } from '@patternfly/react-icons/dist/esm/icons';
 import { ReactReduxContext } from 'react-redux';
 import { TeamsTable } from './TeamsTable';
-import { bool } from 'prop-types';
 
 interface AlertInfo {
   title: string;

--- a/frontend/src/app/Teams/TeamsTable.tsx
+++ b/frontend/src/app/Teams/TeamsTable.tsx
@@ -38,7 +38,7 @@ export const TeamsTable: React.FunctionComponent = () => {
         setToUpdateTeam(team)
         setNewTeamName(team.team_name)
         setNewTeamDesc(team.description)
-        setJiraProjects(team.jira_keys.split(","))
+        setJiraProjects(team.jira_keys?.split(","))
     }
 
     const deleteTeam = (team: ITeam) => {
@@ -157,7 +157,7 @@ export const TeamsTable: React.FunctionComponent = () => {
                         <TextArea value={newTeamDesc} type="text" onChange={(value) => { setNewTeamDesc(value) }} aria-label="text area example" placeholder="Update your team description" />
                     </FormGroup>
                     <FormGroup label="Jira Projects" fieldId='jira-projects' helperText="Update Jira Projects">
-                        <JiraProjects onChange={onJiraProjectsSelected}></JiraProjects>
+                        <JiraProjects onChange={onJiraProjectsSelected} teamJiraKeys={toUpdateTeam?.jira_keys}></JiraProjects>
                     </FormGroup>
                 </Form>
             </Modal>


### PR DESCRIPTION
# Description

- When editing a team, list the Jira projects associated with the target team on "Chosen options"
- Include the Jira project key in the list of projects
- Update jira page when editing jira keys

## Issue ticket number and link
[AD-77](https://issues.redhat.com/browse/AD-77)
[AD-78](https://issues.redhat.com/browse/AD-78)