### PR TITLE
[AD-95] - enable to zoom in into time period

### DIFF
--- a/backend/api/apis/jira/v1alpha1/bugs_types.go
+++ b/backend/api/apis/jira/v1alpha1/bugs_types.go
@@ -50,10 +50,10 @@ type ResolutionTime struct {
 
 	NumberOfTotalBugs int `json:"resolved_bugs"`
 
-	Months []MonthsResolution `json:"months"`
+	Days []DaysResolution `json:"days"`
 }
 
-type MonthsResolution struct {
+type DaysResolution struct {
 	Name string `json:"name"`
 
 	Total float64 `json:"total"`
@@ -63,7 +63,7 @@ type MonthsResolution struct {
 	Bugs []*db.Bugs `json:"bugs"`
 }
 
-// Retrive metrics for open Bugs only
+// Retrieve metrics for open Bugs only
 type OpenBugsMetrics struct {
 	TotalOpenBugs OpenBugs `json:"open"`
 }
@@ -73,10 +73,10 @@ type OpenBugs struct {
 
 	NumberOfOpenBugs int `json:"open_bugs"`
 
-	Months []MonthsOpen `json:"months"`
+	Days []DaysOpen `json:"days"`
 }
 
-type MonthsOpen struct {
+type DaysOpen struct {
 	Name string `json:"name"`
 
 	OpenBugs int `json:"open_bugs"`

--- a/backend/api/server/router/jira/jira.go
+++ b/backend/api/server/router/jira/jira.go
@@ -17,7 +17,7 @@ import (
 // @Router /jira/bugs/e2e [get]
 // @Success 200 {object} []jira.Issue
 func (s *jiraRouter) listE2EBugsKnown(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	issues := s.Jira.GetIssueByJQLQuery(`project in (STONE, DEVHAS, SRVKP, GITOPSRVCE, HACBS) AND status not in (Closed) AND labels = ci-fail`)
+	issues := s.Jira.GetIssueByJQLQuery(`project in (DEVHAS, SRVKP, GITOPSRVCE, HACBS, RHTAP, RHTAPBUGS) AND status not in (Closed) AND labels = ci-fail`)
 
 	return httputils.WriteJSON(w, http.StatusOK, issues)
 }

--- a/backend/api/server/router/jira/jira_route.go
+++ b/backend/api/server/router/jira/jira_route.go
@@ -29,7 +29,7 @@ func NewRouter(s storage.Storage) router.Router {
 	r.Route = []router.Route{
 		router.NewGetRoute("/jira/bugs/e2e", r.listE2EBugsKnown),
 		router.NewGetRoute("/jira/bugs/all", r.listAllBugs), ///jira/project/list
-		router.NewGetRoute("/jira/bugs/metrics/priorities", r.getCountBugsForAlCategories),
+		router.NewGetRoute("/jira/bugs/metrics/priorities", r.getCountBugsForAllCategories),
 		router.NewGetRoute("/jira/project/list", r.getJiraProjects),
 		router.NewPostRoute("/jira/bugs/metrics/resolution", r.calculateRates),
 		router.NewPostRoute("/jira/bugs/metrics/open", r.openBugsMetrics),

--- a/backend/pkg/storage/ent/client/utils.go
+++ b/backend/pkg/storage/ent/client/utils.go
@@ -50,3 +50,26 @@ func isSameDay(startDate, endDate string) bool {
 	}
 	return false
 }
+
+// getRange gets the start and end date
+func getRange(i int, day string, dayArr []string) (string, string) {
+	t, _ := time.Parse("2006-01-02 15:04:05", day)
+	y, m, dd := t.Date()
+	start := ""
+	end := ""
+
+	if i == 0 { // first day
+		start = day
+		end = fmt.Sprintf("%04d-%02d-%02d 23:59:59", y, m, dd)
+	} else {
+		if i == len(dayArr)-1 { // last day
+			start = fmt.Sprintf("%04d-%02d-%02d 00:00:00", y, m, dd)
+			end = day
+		} else { // middle days
+			start = fmt.Sprintf("%04d-%02d-%02d 00:00:00", y, m, dd)
+			end = fmt.Sprintf("%04d-%02d-%02d 23:59:59", y, m, dd)
+		}
+	}
+
+	return start, end
+}

--- a/backend/pkg/storage/storage.go
+++ b/backend/pkg/storage/storage.go
@@ -27,7 +27,7 @@ type Storage interface {
 	Close() error
 
 	// GET
-	TotalBugsResolutionTime(priority string, team *db.Teams) (bugsMetrics jiraV1Alpha1.ResolvedBugsMetrics, err error)
+	TotalBugsResolutionTime(priority, startDate, endDate string, team *db.Teams) (bugsMetrics jiraV1Alpha1.ResolvedBugsMetrics, err error)
 	GetRepository(repositoryName string, gitOrganizationName string) (*db.Repository, error)
 	GetLatestProwTestExecution(r *db.Repository, jobType string) (*db.ProwJobs, error)
 	GetSuitesByJobID(jobID string) ([]*db.ProwSuites, error)
@@ -53,7 +53,7 @@ type Storage interface {
 	UpdateCoverage(codecov coverageV1Alpha1.Coverage, repoName string) error
 	CreateJiraBug(bugsArr []jira.Issue, team *db.Teams) error
 	UpdateTeam(t *db.Teams, target string) error
-	GetOpenBugsMetricsByStatusAndPriority(priority string, team *db.Teams) (bugsMetrics jiraV1Alpha1.OpenBugsMetrics, err error)
+	GetOpenBugsMetricsByStatusAndPriority(priority, startDate, endDate string, team *db.Teams) (bugsMetrics jiraV1Alpha1.OpenBugsMetrics, err error)
 	CreatePullRequests(prs repoV1Alpha1.PullRequests, repo_id string) error
 
 	// Delete

--- a/frontend/src/app/Github/PullRequests.tsx
+++ b/frontend/src/app/Github/PullRequests.tsx
@@ -11,6 +11,7 @@ import {
 } from '@patternfly/react-charts';
 import { DashboardLineChartData } from '@app/utils/sharedComponents';
 import { HelpIcon } from '@patternfly/react-icons';
+import { getLabels } from '@app/utils/utils';
 
 export interface PrsStatistics {
   metrics: Metrics[];
@@ -98,7 +99,7 @@ const getMaxY = (data: DashboardLineChartData) => {
 };
 
 export const PullRequestsGraphic = (props) => {
-  const CursorVoronoiContainer = createContainer('voronoi', 'cursor');
+  const ZoomVoronoiContainer = createContainer("zoom", "voronoi");
   const legendData = [
     { childName: 'created prs', name: 'Created PRs' },
     { childName: 'merged prs', name: 'Merged PRs' },
@@ -143,15 +144,12 @@ export const PullRequestsGraphic = (props) => {
         </Title>
         <Chart
           ariaDesc="Average number of pets"
-          ariaTitle="Line chart example"
           containerComponent={
-            <CursorVoronoiContainer
-              cursorDimension="x"
-              labels={({ datum }) => `${datum.y}`}
-              labelComponent={<ChartLegendTooltip legendData={legendData} title={(datum) => datum.x} />}
-              mouseFollowTooltips
+            <ZoomVoronoiContainer
+              labels={({ datum }) => getLabels(datum, "created_prs")}
               voronoiDimension="x"
-              voronoiPadding={50}
+              voronoiPadding={0}
+              constrainToVisibleArea
             />
           }
           legendData={legendData}

--- a/frontend/src/app/Github/PullRequests.tsx
+++ b/frontend/src/app/Github/PullRequests.tsx
@@ -4,7 +4,6 @@ import {
   Chart,
   ChartAxis,
   ChartGroup,
-  ChartLegendTooltip,
   ChartLine,
   ChartThemeColor,
   createContainer,

--- a/frontend/src/app/Jira/Jira.tsx
+++ b/frontend/src/app/Jira/Jira.tsx
@@ -25,10 +25,13 @@ import {
     Td,
     ThProps
 } from '@patternfly/react-table';
-import { Chart, ChartAxis, ChartGroup, ChartLine, ChartBar } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartGroup, ChartLine, createContainer, ChartThemeColor } from '@patternfly/react-charts';
 import { getJirasResolutionTime, getJirasOpen, listE2EBugsKnown } from '@app/utils/APIService';
 import { ReactReduxContext, useSelector } from 'react-redux';
-import { formatDate } from '@app/Reports/utils';
+import { formatDate, getRangeDates } from '@app/Reports/utils';
+import { DateTimeRangePicker } from '@app/utils/DateTimeRangePicker';
+import { useHistory } from 'react-router-dom';
+import { getLabels } from '@app/utils/utils';
 
 interface Bugs {
     jira_key: string;
@@ -55,11 +58,41 @@ export const Jira = () => {
     const currentTeam = useSelector((state: any) => state.teams.Team);
     const [bugsKnown, setBugsKnown] = useState<any>({});
     const BugsAffectingCI = "Bugs Affecting CI"
+    const [rangeDateTime, setRangeDateTime] = useState(getRangeDates(30));
+    const priorities = ["Global", "Major", "Critical", "Blocker", "Normal", "Undefined", "Minor"]
+
+    const getJiraData = (ID) => {
+        const newData = {}
+
+        const promises = new Array()
+        priorities.forEach(p => {
+            promises.push(getJirasOpen(p, state.teams.Team, rangeDateTime))
+            promises.push(getJirasResolutionTime(p, state.teams.Team, rangeDateTime))
+        })
+
+        Promise.all(promises).then(function (values) {
+            values.map(value => {
+                if (value.data.hasOwnProperty("open")) {
+                    if (!newData.hasOwnProperty(value.data.open.priority)) {
+                        newData[value.data.open.priority] = {}
+                    }
+                    newData[value.data.open.priority].open = value.data.open
+                } else if (value.data.hasOwnProperty("resolution_time")) {
+                    if (!newData.hasOwnProperty(value.data.resolution_time.priority)) {
+                        newData[value.data.open.priority] = {}
+                    }
+                    newData[value.data.resolution_time.priority].resolved = value.data.resolution_time
+                }
+            })
+            setApiDataCache(newData)
+            setSelected(ID)
+        });
+    }
 
     useEffect(() => {
         if (currentTeam != "") {
             listE2EBugsKnown().then(res => {
-                let bugs = new Array<Bugs>
+                const bugs = new Array<Bugs>
                 res.data.forEach((bug, _) => {
                     bugs.push({
                         jira_key: bug.key,
@@ -83,34 +116,17 @@ export const Jira = () => {
             })
 
             const ID = "Global"
-            let newData = {}
+            getJiraData(ID)
 
-            const promises = new Array()
-            const priorities = ["Global", "Major", "Critical", "Blocker", "Normal", "Undefined", "Minor"]
-            priorities.forEach(p => {
-                promises.push(getJirasOpen(p, state.teams.Team))
-                promises.push(getJirasResolutionTime(p, state.teams.Team))
-            })
+            const start = params.get("start")
+            const end = params.get("end")
 
-            Promise.all(promises).then(function (values) {
-
-                values.map(value => {
-                    if (value.data.hasOwnProperty("open")) {
-                        if (!newData.hasOwnProperty(value.data.open.priority)) {
-                            newData[value.data.open.priority] = {}
-                        }
-                        newData[value.data.open.priority].open = value.data.open
-                    } else if (value.data.hasOwnProperty("resolution_time")) {
-                        if (!newData.hasOwnProperty(value.data.resolution_time.priority)) {
-                            newData[value.data.open.priority] = {}
-                        }
-                        newData[value.data.resolution_time.priority].resolved = value.data.resolution_time
-                    }
-                })
-                setApiDataCache(newData)
-                setSelected(ID)
-
-            });
+            if (start == null || end == null) {
+                history.push('/home/jira?team=' + currentTeam + '&start=' + formatDate(rangeDateTime[0]) + '&end=' + formatDate(rangeDateTime[1]))
+            } else {
+                setRangeDateTime([new Date(start), new Date(end)])
+                history.push('/home/jira?team=' + currentTeam + '&start=' + start + '&end=' + end)
+            }
         }
     }, [currentTeam]);
 
@@ -122,6 +138,8 @@ export const Jira = () => {
     const [graphicsVisible, setGraphicsVisible] = useState(false);
     // longVersionVisible indicates if 'resolved_at' and 'resolution_time' should be displayed in bugs table
     const [longVersionVisible, setLongVersionVisible] = useState(false);
+    const history = useHistory();
+    const params = new URLSearchParams(window.location.search);
 
     const [isSelected, setIsSelected] = React.useState('open');
 
@@ -131,13 +149,19 @@ export const Jira = () => {
         setIsSelected(id);
     };
 
+    useEffect(() => {
+        if (selected != "") {
+            getJiraData(selected)
+
+        }
+    }, [rangeDateTime]);
+
     const onClick = (event: React.MouseEvent) => {
-        let ID = event.currentTarget.id
+        const ID = event.currentTarget.id
         if (selected != ID) {
             if (!apiDataCache.hasOwnProperty(ID)) {
-                const promise0 = getJirasOpen(ID, state.teams.Team)
-                const promise1 = getJirasResolutionTime(ID, state.teams.Team)
-
+                const promise0 = getJirasOpen(ID, state.teams.Team, rangeDateTime)
+                const promise1 = getJirasResolutionTime(ID, state.teams.Team, rangeDateTime)
                 Promise.all([promise0, promise1]).then(function (values) {
                     let newData = {}
                     newData[ID] = {}
@@ -159,33 +183,32 @@ export const Jira = () => {
 
     useEffect(() => {
         if (apiDataCache[selected] && selected != BugsAffectingCI) {
-            let rtc = new Array(12).fill(0)
-            let bc = new Array(12).fill(0)
+            let rtc = new Array()
+            let bc = new Array()
             let rbt = new Array()
             let obt = new Array()
-            let obc = new Array(12).fill(0)
+            let obc = new Array()
 
-            apiDataCache[selected].resolved.months.map((item, index) => {
-                let date = item.name.match(/([^_]+)/g)
-                rtc[11 - index] = {
+            apiDataCache[selected].resolved.days.map((item, index) => {
+                rtc.push({
                     name: "Resolution Time (" + selected + ")",
-                    x: date[0].slice(0, 3) + "\n" + date[1],
+                    x: new Date(item.name).toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: '2-digit' }),
                     y: item.total
-                }
-                bc[11 - index] = {
+                })
+                bc.push({
                     name: "Resolved Bugs (" + selected + ")",
-                    x: date[0].slice(0, 3) + "\n" + date[1],
+                    x: new Date(item.name).toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: '2-digit' }),
                     y: item.resolved_bugs
-                }
+                })
                 rbt = [...rbt, ...item.bugs]
             })
-            apiDataCache[selected].open.months.map((item, index) => {
+            apiDataCache[selected].open.days.map((item, index) => {
                 let date = item.name.match(/([^_]+)/g)
-                obc[11 - index] = {
+                obc.push({
                     name: "Open Bugs (" + selected + ")",
-                    x: date[0].slice(0, 3) + "\n" + date[1],
+                    x: new Date(item.name).toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: '2-digit' }),
                     y: item.open_bugs
-                }
+                })
                 obt = [...obt, ...item.bugs]
             })
 
@@ -214,6 +237,13 @@ export const Jira = () => {
         console.log("clicked", event)
     }
 
+    function handleChange(event, from, to) {
+        setRangeDateTime([from, to])
+        params.set("start", formatDate(from))
+        params.set("end", formatDate(to))
+        history.push(window.location.pathname + '?' + params.toString());
+    }
+
     return (
         <React.Fragment>
             <PageSection style={{
@@ -234,28 +264,36 @@ export const Jira = () => {
             <PageSection>
                 <React.Fragment>
                     <Grid hasGutter>
+                        <GridItem>
+                            <DateTimeRangePicker
+                                startDate={rangeDateTime[0]}
+                                endDate={rangeDateTime[1]}
+                                handleChange={(event, from, to) => handleChange(event, from, to)}
+                            >
+                            </DateTimeRangePicker>
+                        </GridItem>
                         {graphicsVisible && <GridItem order={{ default: "2" }}>
                             <Grid hasGutter sm={6} md={6} lg={6} xl={6}>
                                 <GridItem order={{ default: "1" }}>
                                     <Card style={{ textAlign: 'center' }}>
-                                        <CardTitle style={{ textAlign: 'center' }}>Average Resolution Time (for past 12 months)</CardTitle>
+                                        <CardTitle style={{ textAlign: 'center' }}>Average Resolution Time</CardTitle>
                                         <CardBody>
                                             <Title headingLevel='h1' size="2xl">
                                                 {apiDataCache[selected] &&
                                                     <span>
-                                                        <span>{parseFloat(apiDataCache[selected].resolved.total).toFixed(2) || "-"}</span>
-                                                        <span style={{ paddingLeft: '5px', fontSize: '15px', fontWeight: 'normal' }}>hours</span>
+                                                        <span>{parseFloat(apiDataCache[selected].resolved.total) || "-"}</span>
+                                                        <span style={{ paddingLeft: '5px', fontSize: '15px', fontWeight: 'normal' }}>day(s)</span>
                                                     </span>
                                                 }
                                                 {!apiDataCache[selected] && "-"}
                                             </Title>
-                                            <BugsChart chartType="line" data={resolutionTimeChart} onBarClick={onBarChartClick}></BugsChart>
+                                            <BugsChart chartTitle="Average Resolution Time" data={resolutionTimeChart} onBarClick={onBarChartClick}></BugsChart>
                                         </CardBody>
                                     </Card>
                                 </GridItem>
                                 <GridItem order={{ default: "2" }}>
                                     <Card style={{ textAlign: 'center' }}>
-                                        <CardTitle>Bugs (past 12 months)</CardTitle>
+                                        <CardTitle>Bugs</CardTitle>
                                         <CardBody>
                                             <Title headingLevel='h1' size="2xl">
                                                 {apiDataCache[selected] &&
@@ -268,7 +306,7 @@ export const Jira = () => {
                                                 }
                                                 {!apiDataCache[selected] && "-"}
                                             </Title>
-                                            <BugsChart chartType="bar" data={bugsChart} onBarClick={onBarChartClick}></BugsChart>
+                                            <BugsChart chartTitle="Bugs" data={bugsChart} onBarClick={onBarChartClick}></BugsChart>
                                         </CardBody>
                                     </Card>
                                 </GridItem>
@@ -412,8 +450,9 @@ export const Jira = () => {
         </React.Fragment>
     )
 }
-
-const BugsChart: React.FC<{ chartType: string, data: any, onBarClick: any }> = ({ chartType, data, onBarClick }) => {
+const BugsChart: React.FC<{ chartTitle: string, data: any, onBarClick: any }> = ({ chartTitle, data, onBarClick }) => {
+    const ZoomVoronoiContainer = createContainer("zoom", "voronoi");
+    
     let legendData: { name: string }[] = []
     if (data.length > 0) {
         legendData = data.map((dataset, index) => {
@@ -421,60 +460,68 @@ const BugsChart: React.FC<{ chartType: string, data: any, onBarClick: any }> = (
         })
     }
 
+    const getMaxY = (data) => {
+        let maxY = 0;
+        data.map((dataset, idx) => {
+            dataset.forEach((data) => {
+                if (data.y > maxY) {
+                    maxY = data.y;
+                }
+            })
+        })
+
+        return maxY
+    };
+
+    const maxY = getMaxY(data);
+
     return (
         <div style={{ margin: '0 auto', height: '60%', width: '90%', marginTop: '15px' }}>
             {data.length > 0 &&
                 <Chart
-                    ariaDesc="Average number of pets"
-                    ariaTitle="Line chart example"
                     height={210}
+                    containerComponent={
+                        <ZoomVoronoiContainer
+                            labels={({ datum }) => chartTitle == "Bugs" ? getLabels(datum, "Resolved Bugs") : getLabels(datum, "Resolution Time")}
+                            voronoiDimension="x"
+                            voronoiPadding={0}
+                            constrainToVisibleArea
+                        />
+                    }
                     legendData={legendData}
                     legendPosition='bottom'
                     padding={{
                         bottom: 70,
                         left: 40,
-                        right: 14,
+                        right: 40,
                         top: 20
                     }}
+                    name="chart"
+                    themeColor={ChartThemeColor.blue}
+                    maxDomain={{ y: maxY + 1 }}
+                    minDomain={{ y: 0 }}
                 >
-                    <ChartAxis style={{ axisLabel: { fontSize: 8, padding: 30 }, tickLabels: { fontSize: 7 } }} />
-                    <ChartAxis dependentAxis={true} showGrid style={{ axisLabel: { fontSize: 8, padding: 30 }, tickLabels: { fontSize: 8 } }} />
-                    {chartType == 'bar' && data.length > 0 &&
-                        <ChartGroup offset={11}>
-                            {data.map((dataset, index) => (
-                                <ChartBar
-                                    name={"bar_" + index}
-                                    key={index}
-                                    style={{
-                                        data: { strokeWidth: 1 },
-                                        parent: { border: "1px solid #ccc" },
-                                        labels: { fill: "grey", fontSize: '7px' }
-                                    }}
-                                    data={dataset}
-                                    labels={({ datum }) => datum.y != 0 ? `${datum.y}` : ``}
-                                />
-                            ))}
-                        </ChartGroup>
-                    }
-                    {chartType == 'line' && data.length > 0 &&
-                        <ChartGroup offset={11}>
+
+                    <ChartAxis fixLabelOverlap={true} style={{ axisLabel: { fontSize: 8, padding: 30 }, tickLabels: { fontSize: 7 } }} />
+                    <ChartAxis fixLabelOverlap={true} dependentAxis={true} showGrid style={{ axisLabel: { fontSize: 8, padding: 30 }, tickLabels: { fontSize: 8 } }} />
+                    {data.length > 0 &&
+                        <ChartGroup>
                             {data.map((dataset, index) => (
                                 <ChartLine
                                     key={index}
                                     style={{
                                         data: { strokeWidth: 2 },
                                         parent: { border: "1px solid #ccc" },
-                                        labels: { fill: "grey", fontSize: '7px' }
+                                        labels: { fontSize: '10px' }
                                     }}
                                     data={dataset}
-                                    labels={({ datum }) => `${parseInt(datum.y)}`}
                                 />
                             ))}
                         </ChartGroup>
                     }
                 </Chart>
             }
-        </div>
+            </div>
     );
 }
 
@@ -696,7 +743,7 @@ const ComposableTableStripedTr: React.FC<{ bugs: any, longVersion: boolean }> = 
                             <Td dataLabel={columnNames.created_at}>{formatDate(new Date(bug.created_at))}</Td>
                             <Td dataLabel={columnNames.updated_at}>{formatDate(new Date(bug.updated_at))}</Td>
                             {longVersion && <Td dataLabel={columnNames.resolved_at}>{formatDate(new Date(bug.resolved_at))}</Td>}
-                            {longVersion && <Td dataLabel={columnNames.resolution_time}>{!Number.isNaN(parseFloat(bug.resolution_time)) ? parseFloat(bug.resolution_time).toFixed(2) + "h" : "-"}</Td>}
+                            {longVersion && <Td dataLabel={columnNames.resolution_time}>{!Number.isNaN(parseFloat(bug.resolution_time)) ? parseFloat(bug.resolution_time) + " day(s)" : "-"}</Td>}
                         </Tr>
                     ))}
                 </Tbody>

--- a/frontend/src/app/Reports/Reports.tsx
+++ b/frontend/src/app/Reports/Reports.tsx
@@ -200,7 +200,7 @@ let Reports = () => {
               const end_date = formatDate(rangeDateTime[1])
 
               history.push('/reports/test?team=' + currentTeam + '&organization=' + data[1].organization + '&repository=' + data[1].repoName
-                + '&job_type=presubmit' + '&start=' + start_date + ' &end=' + end_date)
+                + '&job_type=presubmit' + '&start=' + start_date + '&end=' + end_date)
 
             } else {
               if (validateRepositoryParams(data, repository, organization)) {

--- a/frontend/src/app/Teams/TeamsSelect.tsx
+++ b/frontend/src/app/Teams/TeamsSelect.tsx
@@ -54,6 +54,10 @@ export const BasicMasthead = () => {
     if (history.location.pathname == "/home/github" && team != null && team != event.target.dataset.value) {
       history.push('/home/github?team=' + event.target.dataset.value)
     }
+
+    if (history.location.pathname == "/home/jira" && team != null && team != event.target.dataset.value) {
+      history.push('/home/jira?team=' + event.target.dataset.value)
+    }
   }
 
   function Log_out() {

--- a/frontend/src/app/utils/APIService.ts
+++ b/frontend/src/app/utils/APIService.ts
@@ -425,6 +425,23 @@ async function getProwJobs(repoName: string, repoOrg: string) {
   return data;
 }
 
+async function listE2EBugsKnown() {
+  const result: ApiResponse = { code: 0, data: {} };
+  const subPath = '/api/quality/jira/bugs/e2e';
+  const uri = API_URL + subPath;
+  await axios
+    .get(uri)
+    .then((res: AxiosResponse) => {
+      result.code = res.status;
+      result.data = res.data;
+    })
+    .catch((err) => {
+      result.code = err.response.status;
+      result.data = err.response.data;
+    });
+  return result;
+}
+
 export {
   getVersion,
   getRepositories,
@@ -445,4 +462,5 @@ export {
   getJirasOpen,
   listJiraProjects,
   getPullRequests,
+  listE2EBugsKnown,
 };

--- a/frontend/src/app/utils/APIService.ts
+++ b/frontend/src/app/utils/APIService.ts
@@ -60,14 +60,19 @@ async function getJiras() {
   return result;
 }
 
-async function getJirasResolutionTime(priority: string, team: string) {
+async function getJirasResolutionTime(priority: string, team: string, rangeDateTime: Date[]) {
   const result: ApiResponse = { code: 0, data: {} };
   const subPath = '/api/quality/jira/bugs/metrics/resolution';
   const uri = API_URL + subPath;
+  const start_date = formatDate(rangeDateTime[0]);
+  const end_date = formatDate(rangeDateTime[1]);
+
   await axios
     .post(uri, {
       priority: priority,
       team_name: team,
+      start: start_date,
+      end: end_date,
     })
     .then((res: AxiosResponse) => {
       result.code = res.status;
@@ -97,7 +102,10 @@ async function listJiraProjects() {
   return result;
 }
 
-async function getJirasOpen(priority: string, team: string) {
+async function getJirasOpen(priority: string, team: string, rangeDateTime: Date[]) {
+  const start_date = formatDate(rangeDateTime[0]);
+  const end_date = formatDate(rangeDateTime[1]);
+
   const result: ApiResponse = { code: 0, data: {} };
   const subPath = '/api/quality/jira/bugs/metrics/open';
   const uri = API_URL + subPath;
@@ -105,6 +113,8 @@ async function getJirasOpen(priority: string, team: string) {
     .post(uri, {
       priority: priority,
       team_name: team,
+      start: start_date,
+      end: end_date,
     })
     .then((res: AxiosResponse) => {
       result.code = res.status;

--- a/frontend/src/app/utils/sharedComponents.tsx
+++ b/frontend/src/app/utils/sharedComponents.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useLayoutEffect, useRef } from 'react';
 import { ExclamationCircleIcon, OkIcon, HelpIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Card, CardTitle, CardBody, Badge } from '@patternfly/react-core';
-import { Chart, ChartAxis, ChartLine, ChartGroup, ChartVoronoiContainer, ChartLegend } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartLine, ChartGroup, ChartLegend, createContainer } from '@patternfly/react-charts';
 import { SimpleList, SimpleListItem } from '@patternfly/react-core';
+import { getLabels } from './utils';
 
 /* 
 Some common useful types definition
@@ -109,6 +110,7 @@ export const DashboardLineChart = ({ data, colorScale }: { data: DashboardLineCh
   let beautifiedData = data
   const [width, setWidth] = useState(0);
   const [height, setHeight] = useState(0);
+  const ZoomVoronoiContainer = createContainer("zoom", "voronoi");
 
   useLayoutEffect(() => {
     if (ref.current) {
@@ -142,8 +144,14 @@ export const DashboardLineChart = ({ data, colorScale }: { data: DashboardLineCh
       <div style={{ height: height + 'px', width: width + 'px', background: "white" }}>
         <Chart
           ariaDesc="Average number of pets"
-          ariaTitle="Bar chart example"
-          containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+          containerComponent={
+            <ZoomVoronoiContainer
+              labels={({ datum }) => getLabels(datum, "success_rate")}
+              voronoiDimension="x"
+              voronoiPadding={0}
+              constrainToVisibleArea
+            />
+          }
           legendOrientation="horizontal"
           legendPosition="bottom"
           legendComponent={getLegend(legendData)}

--- a/frontend/src/app/utils/utils.ts
+++ b/frontend/src/app/utils/utils.ts
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import { useSelector } from 'react-redux';
 
 export function accessibleRouteChangeHandler() {

--- a/frontend/src/app/utils/utils.ts
+++ b/frontend/src/app/utils/utils.ts
@@ -72,3 +72,12 @@ export function validateParam(params, param) {
   }
   return false;
 }
+
+// getLabels gets the labels, considering its name prefix
+export const getLabels = (datum, prefix) => {
+  if (!datum.name.startsWith(prefix)) {
+    return `${datum.name} : ${datum.y}`;
+  }
+
+  return `${datum.x} \n ${datum.name} : ${datum.y}`;
+};


### PR DESCRIPTION
# Description

- [AD-95] enable to zoom in into time period in Jira, Github, and OpenShift CI charts
- added improvements on Jira:
  -  changed resolution time from hours to days (backend) 
  -  changed jira bugs data from months to days (backend)
  -  changed default time range to 30 days instead of 12 months
  -  added time range support
  -  added custom routes support 
  -  added loading page



## Issue ticket number and link
[AD-95](https://issues.redhat.com/browse/AD-95)