### PR TITLE
Fix kube-linter issues

### DIFF
--- a/backend/deploy/base/deployment.yaml
+++ b/backend/deploy/base/deployment.yaml
@@ -76,6 +76,7 @@ spec:
             capabilities:
               drop:
                 - ALL
+            readOnlyRootFilesystem: true
           ports:
             - name: http
               containerPort: 8000
@@ -83,3 +84,5 @@ spec:
           imagePullPolicy: Always
           image: >-
             quay.io/redhat-appstudio/quality-dashboard-backend:latest
+      securityContext:
+        runAsNonRoot: true

--- a/frontend/deploy/base/deployment.yaml
+++ b/frontend/deploy/base/deployment.yaml
@@ -58,6 +58,8 @@ spec:
             requests:
               cpu: 100m
               memory: 100Mi
+          securityContext:
+            readOnlyRootFilesystem: true
         - resources:
             limits:
               cpu: 500m
@@ -79,6 +81,8 @@ spec:
           imagePullPolicy: Always
           image: >-
             quay.io/redhat-appstudio/quality-dashboard-frontend:latest
+          securityContext:
+            readOnlyRootFilesystem: true
       volumes:
         - name: proxy-tls
           secret:
@@ -87,3 +91,5 @@ spec:
           secret:
             secretName: quality-dashboard-auth
             defaultMode: 420
+      securityContext:
+        runAsNonRoot: true


### PR DESCRIPTION
Set runAsNonRoot and  readOnlyRootFilesystem to true for pods/containers.