### PR TITLE
Revert readOnlyRootFilesystem for quality-frontend-dashboard container

### DIFF
--- a/frontend/deploy/base/deployment.yaml
+++ b/frontend/deploy/base/deployment.yaml
@@ -81,8 +81,6 @@ spec:
           imagePullPolicy: Always
           image: >-
             quay.io/redhat-appstudio/quality-dashboard-frontend:latest
-          securityContext:
-            readOnlyRootFilesystem: true
       volumes:
         - name: proxy-tls
           secret:


### PR DESCRIPTION
The entrypoint is changing files using sed so the container fails to start since readOnlyRootFilesystem was introduced in bb70cddf67540b46a218024ac29f520f7a63dd2e