### PR TITLE
fix: [AD-120] Correcting Retest Before Merge Avg metric

### DIFF
--- a/backend/api/apis/github/v1alpha1/prs.go
+++ b/backend/api/apis/github/v1alpha1/prs.go
@@ -36,7 +36,7 @@ type PullRequest struct {
 	MergedBy      *PullRequestAuthor
 	Repository    Repository
 	MergeCommit   Commit
-	TimelineItems `graphql:"timelineItems(first:100, itemTypes:[ISSUE_COMMENT])"`
+	TimelineItems `graphql:"timelineItems(first:100, itemTypes:[ISSUE_COMMENT, PULL_REQUEST_COMMIT])"`
 }
 
 // PullRequests is a list of GitHub Pull Requests

--- a/backend/pkg/connectors/github/pull_requests_query.go
+++ b/backend/pkg/connectors/github/pull_requests_query.go
@@ -29,7 +29,8 @@ type QueryListPullRequests struct {
 			PullRequest githubV1Alhpa1.PullRequest `graphql:"... on PullRequest"`
 		}
 		PageInfo githubV1Alhpa1.PageInfo
-	} `graphql:"search(query: $query, type: ISSUE, first: 100, after: $cursor)"`
+		// Do not set the number of PRs per page too high to avoid query timeout
+	} `graphql:"search(query: $query, type: ISSUE, first: 50, after: $cursor)"`
 }
 
 // GetAllPullRequests uses the graphql search endpoint API to search all pull requests in the repository
@@ -49,7 +50,6 @@ func (gh *Github) GetAllPullRequests(ctx context.Context, opts githubV1Alhpa1.Li
 			return nil, errors.WithStack(err)
 		}
 		prs := make([]githubV1Alhpa1.PullRequest, len(q.Search.Nodes))
-
 		for i, v := range q.Search.Nodes {
 			prs[i] = v.PullRequest
 		}


### PR DESCRIPTION
This PR adds PULL_REQUEST_COMMIT to graphql query for getting TimelineItems. This change makes it possible to determine time of the last commit before merging a PR. It also changes the number of PRs returned per query to avoid timeout.

Issue:
[AD-120](https://issues.redhat.com/browse/AD-120)