### PR TITLE
fix nil pointer

### DIFF
--- a/backend/api/server/router/jira/bug_slos.go
+++ b/backend/api/server/router/jira/bug_slos.go
@@ -37,7 +37,6 @@ func GetResponseSLI(bug *db.Bugs) *Alert {
 	alert := &Alert{Signal: "green"}
 
 	if bug.DaysWithoutAssignee != nil && (bug.Priority == "Blocker" || bug.Priority == "Critical") {
-		fmt.Println(bug.DaysWithoutAssignee)
 		if *bug.DaysWithoutAssignee > 2 {
 			msg := fmt.Sprintf("Issue <%s|%s> is not meeting defined Bug SLO for Blocker and Critical Bug Response Time. Blocker and Critical bugs should be assigned between a maximum of 2 days. This issue has assignee undefined for %.2f days. Please, take a time to assign it.\n\n",
 				bug.URL,

--- a/backend/api/server/router/jira/bug_slos.go
+++ b/backend/api/server/router/jira/bug_slos.go
@@ -13,11 +13,11 @@ import (
 func GetTriageSLI(bug *db.Bugs) *Alert {
 	alert := &Alert{Signal: "green"}
 
-	if bug.Labels != nil && strings.Contains(*bug.Labels, "untriaged") {
+	if bug.Labels != nil && bug.DaysWithoutPriority != nil && strings.Contains(*bug.Labels, "untriaged") {
 		msg := fmt.Sprintf("Issue <%s|%s> is not meeting defined Bug SLO for Triage Time. Priority should be defined between a maximum of 2 days. This issue has priority undefined for %.2f days. Please, take a time to resolve it.\n\n",
 			bug.URL,
 			bug.JiraKey,
-			*bug.DaysWithoutResolution,
+			*bug.DaysWithoutPriority,
 		)
 
 		if *bug.DaysWithoutPriority > 2 {
@@ -35,7 +35,9 @@ func GetTriageSLI(bug *db.Bugs) *Alert {
 // GetResponseSLI should return red if there is no assignee for more than 2 days on Blocker and Critical bugs
 func GetResponseSLI(bug *db.Bugs) *Alert {
 	alert := &Alert{Signal: "green"}
-	if bug.Priority == "Blocker" || bug.Priority == "Critical" {
+
+	if bug.DaysWithoutAssignee != nil && (bug.Priority == "Blocker" || bug.Priority == "Critical") {
+		fmt.Println(bug.DaysWithoutAssignee)
 		if *bug.DaysWithoutAssignee > 2 {
 			msg := fmt.Sprintf("Issue <%s|%s> is not meeting defined Bug SLO for Blocker and Critical Bug Response Time. Blocker and Critical bugs should be assigned between a maximum of 2 days. This issue has assignee undefined for %.2f days. Please, take a time to assign it.\n\n",
 				bug.URL,
@@ -52,22 +54,25 @@ func GetResponseSLI(bug *db.Bugs) *Alert {
 
 func measureBugResolutionSLI(redThreshold, yellowThreshold float64, bug *db.Bugs) *Alert {
 	alert := &Alert{Signal: "green"}
-	daysWithoutResolution := *bug.DaysWithoutResolution
 
-	msg := fmt.Sprintf("Issue <%s|%s> is not meeting defined Bug SLO for %s Bug Resolution Time. %s bugs should not take more than 10 days to be resolved. This issue is not resolved for %.2f days. Please, take a time to resolve it.\n\n",
-		bug.URL,
-		bug.JiraKey,
-		bug.Priority,
-		bug.Priority,
-		daysWithoutResolution,
-	)
+	if bug.DaysWithoutResolution != nil {
+		daysWithoutResolution := *bug.DaysWithoutResolution
 
-	if daysWithoutResolution > redThreshold {
-		alert.Signal = "red"
-		alert.AlertMessage = &msg
-	} else if daysWithoutResolution > yellowThreshold {
-		alert.Signal = "yellow"
-		alert.AlertMessage = &msg
+		msg := fmt.Sprintf("Issue <%s|%s> is not meeting defined Bug SLO for %s Bug Resolution Time. %s bugs should not take more than 10 days to be resolved. This issue is not resolved for %.2f days. Please, take a time to resolve it.\n\n",
+			bug.URL,
+			bug.JiraKey,
+			bug.Priority,
+			bug.Priority,
+			daysWithoutResolution,
+		)
+
+		if daysWithoutResolution > redThreshold {
+			alert.Signal = "red"
+			alert.AlertMessage = &msg
+		} else if daysWithoutResolution > yellowThreshold {
+			alert.Signal = "yellow"
+			alert.AlertMessage = &msg
+		}
 	}
 
 	return alert

--- a/backend/pkg/connectors/github/repositories.go
+++ b/backend/pkg/connectors/github/repositories.go
@@ -18,11 +18,11 @@ var (
 
 func (g *Github) GetGithubRepositoryInformation(organization string, repository string) (*github.Repository, error) {
 	repo, resp, err := g.client.Repositories.Get(context.Background(), organization, repository)
-	if resp.StatusCode != 200 {
-		return nil, GENERIC_ERROR_GIT_RESPONSE
-	}
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, GENERIC_ERROR_GIT_RESPONSE
 	}
 	return repo, nil
 }


### PR DESCRIPTION
The present PR fixes the following panic:

```
2023-10-20T16:48:08.553Z	info	server/server.go:215	Registering route	{"Path": "/api/quality/failures/delete", "Method": "DELETE"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xe289d6]

goroutine 31 [running]:
github.com/redhat-appstudio/quality-studio/api/server/router/jira.measureBugResolutionSLI(0x4044000000000000, 0x4034000000000000, 0xc000002780)
	/github.com/redhat-appstudio-qe/qe-dashboard-backend/api/server/router/jira/bug_slos.go:55 +0x96
github.com/redhat-appstudio/quality-studio/api/server/router/jira.GetResolutionSLI(0xc000002780)
	/github.com/redhat-appstudio-qe/qe-dashboard-backend/api/server/router/jira/bug_slos.go:85 +0x9e
github.com/redhat-appstudio/quality-studio/api/server/router/jira.GetBugSLIs({_, _, _})
	/github.com/redhat-appstudio-qe/qe-dashboard-backend/api/server/router/jira/bug_slos.go:136 +0x11d
github.com/redhat-appstudio/quality-studio/api/server.(*Server).SendBugSLIAlerts(0xc000312cd0)
	/github.com/redhat-appstudio-qe/qe-dashboard-backend/api/server/rhtap_bug_slis_alert.go:153 +0x2b3
github.com/redhat-appstudio/quality-studio/api/server.(*Server).createMux(0xc000312cd0)
	/github.com/redhat-appstudio-qe/qe-dashboard-backend/api/server/server.go:239 +0x285
github.com/redhat-appstudio/quality-studio/api/server.(*Server).serveAPI(0xc000312cd0)
	/github.com/redhat-appstudio-qe/qe-dashboard-backend/api/server/server.go:133 +0x279
github.com/redhat-appstudio/quality-studio/api/server.(*Server).Wait(0xc000312cd0, 0x0?)
	/github.com/redhat-appstudio-qe/qe-dashboard-backend/api/server/server.go:248 +0x38
created by main.main
	/github.com/redhat-appstudio-qe/qe-dashboard-backend/cmd/server/main.go:123 +0xd65
```