### PR TITLE
replace error log with warn log when resp status is 404 in CheckIfRepoExistsInOpenshiftCI

### DIFF
--- a/backend/api/server/server.go
+++ b/backend/api/server/server.go
@@ -235,9 +235,7 @@ func (s *Server) createMux() *mux.Router {
 	m.MethodNotAllowedHandler = notFoundHandler
 
 	str := staticRotationStrategy()
-	s.cfg.Logger.Info("updating db")
 	s.startUpdateStorage(context.TODO(), str, time.Now)
-	s.cfg.Logger.Info("sending slis alerts")
 	s.SendBugSLIAlerts()
 
 	return m

--- a/backend/pkg/connectors/github/content.go
+++ b/backend/pkg/connectors/github/content.go
@@ -11,12 +11,15 @@ import (
 )
 
 func (g *Github) CheckIfRepoExistsInOpenshiftCI(organization string, repository string) bool {
-	fmt.Println("checking if repo exists in Openshift CI")
-	if _, _, _, err := g.client.Repositories.GetContents(context.Background(), "openshift", "release", fmt.Sprintf("ci-operator/config/%s/%s", organization, repository), &github.RepositoryContentGetOptions{
+	if _, _, resp, err := g.client.Repositories.GetContents(context.Background(), "openshift", "release", fmt.Sprintf("ci-operator/config/%s/%s", organization, repository), &github.RepositoryContentGetOptions{
 		Ref: "master",
 	}); err != nil {
 		logger, _ := logger.InitZap("info")
-		logger.Error("repository does not exist in OpenShift CI", zap.String("repository", repository), zap.Error(err))
+		if resp.StatusCode == 404 {
+			logger.Warn(fmt.Sprintf("repository %s/%s does not exist in OpenShift CI", repository, organization))
+		} else {
+			logger.Error("repository does not exist in OpenShift CI", zap.String("repository", repository), zap.Error(err))
+		}
 		return false
 	}
 


### PR DESCRIPTION
Backend logs have a lot of logs regarding not finding a repository in Openshift CI. This is normal since some repos like dora-metrics do not have jobs running. To clean them, this PR replaces error log with warn log.