### PR TITLE
feat: [AD-108] Display whole numbers within the OpenShift CI Test Report Page

### DIFF
--- a/backend/api/apis/prow/v1alpha1/metrics.go
+++ b/backend/api/apis/prow/v1alpha1/metrics.go
@@ -29,15 +29,19 @@ type Jobs struct {
 
 // Set of Metrics for a specific job
 type Metrics struct {
-	// Return the percentage of success
-	SuccessRate float64 `json:"success_rate"`
+	// Return the count of successful jobs
+	SuccessCount float64 `json:"success_count"`
 
-	// Return a percentage about how much fail a job
-	FailureRate float64 `json:"failure_rate"`
+	// Return the count of failed jobs
+	FailureCount float64 `json:"failure_count"`
 
-	// Return percentage of prow ci failures
-	CiFailedRate float64 `json:"ci_failed_rate"`
+	// Return the count of prow ci failures
+	CiFailedCount float64 `json:"ci_failed_count"`
 
+	// Return the total number of jobs
+	TotalJobs float64 `json:"total_jobs"`
+
+	// Return the date
 	Date string `json:"date"`
 }
 
@@ -46,11 +50,11 @@ type Summary struct {
 
 	DateTo string `json:"date_to"`
 
-	SuccessRateAvg float64 `json:"success_rate_avg"`
+	SuccessCount float64 `json:"success_count"`
 
-	JobFailedAvg float64 `json:"failure_rate_avg"`
+	JobFailedCount float64 `json:"failure_count"`
 
-	CIFailedAvg float64 `json:"ci_failed_rate_avg"`
+	CIFailedCount float64 `json:"ci_failed_count"`
 
-	TotalJobs int `json:"total_jobs"`
+	TotalJobs float64 `json:"total_jobs"`
 }

--- a/frontend/src/app/Reports/Reports.tsx
+++ b/frontend/src/app/Reports/Reports.tsx
@@ -305,9 +305,9 @@ let Reports = () => {
 
   if (prowJobsStats) {
     prowJobsStats.jobs[selectedJob].metrics.map(metric => {
-      beautifiedData["SUCCESS_RATE_INDEX"].data.push({ name: 'success_rate', x: new Date(metric.date).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: +metric.success_rate })
-      beautifiedData["FAILURE_RATE_INDEX"].data.push({ name: 'failure_rate', x: new Date(metric.date).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: +metric.failure_rate })
-      beautifiedData["CI_FAILED_RATE_INDEX"].data.push({ name: 'ci_failed_rate', x: new Date(metric.date).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: +metric.ci_failed_rate })
+      beautifiedData["SUCCESS_RATE_INDEX"].data.push({ name: 'success_rate', x: new Date(metric.date).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: + (metric.total_jobs > 0 ? (100 * metric.success_count / metric.total_jobs).toFixed(2) : 0)})
+      beautifiedData["FAILURE_RATE_INDEX"].data.push({ name: 'failure_rate', x: new Date(metric.date).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: +  (metric.total_jobs > 0 ? (100 * metric.failure_count / metric.total_jobs).toFixed(2) : 0)})
+      beautifiedData["CI_FAILED_RATE_INDEX"].data.push({ name: 'ci_failed_rate', x: new Date(metric.date).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: + (metric.total_jobs > 0 ? (100 * metric.ci_failed_count / metric.total_jobs).toFixed(2) : 0)})
     });
 
     beautifiedData["SUCCESS_RATE_INDEX"].style = { data: { stroke: "rgba(30, 79, 24, 0.9)", strokeWidth: 2 } }
@@ -315,20 +315,20 @@ let Reports = () => {
     beautifiedData["CI_FAILED_RATE_INDEX"].style = { data: { stroke: "rgba(240, 171, 0, 0.9)", strokeWidth: 2 } }
 
     beautifiedData["SUCCESS_RATE_AVG_INDEX"].data = [
-      { name: 'success_rate_avg', x: new Date(prowJobsStats.jobs[selectedJob].summary.date_from).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: +prowJobsStats.jobs[selectedJob].summary.success_rate_avg },
-      { name: 'success_rate_avg', x: new Date(prowJobsStats.jobs[selectedJob].summary.date_to).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: +prowJobsStats.jobs[selectedJob].summary.success_rate_avg }
+      { name: 'success_rate_avg', x: new Date(prowJobsStats.jobs[selectedJob].summary.date_from).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: + (100 * prowJobsStats.jobs[selectedJob].summary.success_count / prowJobsStats.jobs[selectedJob].summary.total_jobs).toFixed(2)},
+      { name: 'success_rate_avg', x: new Date(prowJobsStats.jobs[selectedJob].summary.date_to).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: + (100 * prowJobsStats.jobs[selectedJob].summary.success_count / prowJobsStats.jobs[selectedJob].summary.total_jobs).toFixed(2)}
     ]
     beautifiedData["SUCCESS_RATE_AVG_INDEX"].style = { data: { stroke: "rgba(30, 79, 24, 0.3)", strokeDasharray: 10, strokeWidth: 5 } }
 
     beautifiedData["FAILURE_RATE_AVG_INDEX"].data = [
-      { name: 'failure_rate_avg', x: new Date(prowJobsStats.jobs[selectedJob].summary.date_from).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: +prowJobsStats.jobs[selectedJob].summary.failure_rate_avg },
-      { name: 'failure_rate_Avg', x: new Date(prowJobsStats.jobs[selectedJob].summary.date_to).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: +prowJobsStats.jobs[selectedJob].summary.failure_rate_avg }
+      { name: 'failure_rate_avg', x: new Date(prowJobsStats.jobs[selectedJob].summary.date_from).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: + (100 * prowJobsStats.jobs[selectedJob].summary.failure_count / prowJobsStats.jobs[selectedJob].summary.total_jobs).toFixed(2)},
+      { name: 'failure_rate_avg', x: new Date(prowJobsStats.jobs[selectedJob].summary.date_to).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: + (100 * prowJobsStats.jobs[selectedJob].summary.failure_count / prowJobsStats.jobs[selectedJob].summary.total_jobs).toFixed(2)}
     ]
     beautifiedData["FAILURE_RATE_AVG_INDEX"].style = { data: { stroke: "rgba(163, 0, 0, 0.3)", strokeDasharray: 10, strokeWidth: 5 } }
 
     beautifiedData["CI_FAILED_RATE_AVG_INDEX"].data = [
-      { name: 'ci_failed_rate_avg', x: new Date(prowJobsStats.jobs[selectedJob].summary.date_from).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: +prowJobsStats.jobs[selectedJob].summary.ci_failed_rate_avg },
-      { name: 'ci_failed_rate_avg', x: new Date(prowJobsStats.jobs[selectedJob].summary.date_to).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: +prowJobsStats.jobs[selectedJob].summary.ci_failed_rate_avg }
+      { name: 'ci_failed_rate_avg', x: new Date(prowJobsStats.jobs[selectedJob].summary.date_from).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: + (100 * prowJobsStats.jobs[selectedJob].summary.ci_failed_count / prowJobsStats.jobs[selectedJob].summary.total_jobs).toFixed(2)},
+      { name: 'ci_failed_rate_avg', x: new Date(prowJobsStats.jobs[selectedJob].summary.date_to).toLocaleDateString("en-US", { day: 'numeric', month: 'short' }), y: + (100 * prowJobsStats.jobs[selectedJob].summary.ci_failed_count / prowJobsStats.jobs[selectedJob].summary.total_jobs).toFixed(2)}
     ]
     beautifiedData["CI_FAILED_RATE_AVG_INDEX"].style = { data: { stroke: "rgba(240, 171, 0, 0.3)", strokeDasharray: 10, strokeWidth: 5 } }
   }
@@ -438,13 +438,38 @@ let Reports = () => {
 
             {prowJobsStats !== null && <Grid hasGutter style={{ margin: "20px 0px" }} sm={6} md={4} lg={3} xl2={1}>
               <GridItem span={3}><GitHubInfoCard repoName={prowJobsStats.repository_name} org={prowJobsStats.git_organization} data={[{ title: "Repository", value: prowJobsStats.repository_name }, { title: "Organization", value: prowJobsStats.git_organization }]}></GitHubInfoCard></GridItem>
-              <GridItem span={2}><DashboardCard cardType={'danger'} title="CI Failures Avg" body={prowJobsStats?.jobs != null ? parseFloat(prowJobsStats.jobs[selectedJob].summary.ci_failed_rate_avg).toFixed(2) + "%" : "-"}></DashboardCard></GridItem>
-              <GridItem span={2}><DashboardCard cardType={'danger'} title="Failures Avg" body={prowJobsStats?.jobs != null ? parseFloat(prowJobsStats.jobs[selectedJob].summary.failure_rate_avg).toFixed(2) + "%" : "-"}></DashboardCard></GridItem>
-              <GridItem span={2}><DashboardCard cardType={'success'} title="Passed Tests Avg" body={prowJobsStats?.jobs != null ? parseFloat(prowJobsStats.jobs[selectedJob].summary.success_rate_avg).toFixed(2) + "%" : "-"}></DashboardCard></GridItem>
-              <GridItem span={3}><DashboardCard cardType={'default'} title="Total CI Jobs Executed" body={prowJobsStats?.jobs != null ? prowJobsStats.jobs[selectedJob].summary.total_jobs.toString() : "N/A"}></DashboardCard></GridItem>
+              
+              <GridItem span={2}><DashboardCard 
+              cardType={'danger'} 
+              title="CI Failures Avg"
+              body={prowJobsStats?.jobs != null ? (100 * prowJobsStats.jobs[selectedJob].summary.ci_failed_count / prowJobsStats.jobs[selectedJob].summary.total_jobs).toFixed(2) + "%" : "-"}
+              subtext={prowJobsStats?.jobs != null ? (prowJobsStats.jobs[selectedJob].summary.ci_failed_count + "/" + prowJobsStats.jobs[selectedJob].summary.total_jobs) : "-"} 
+              ></DashboardCard></GridItem>
+              
+              <GridItem span={2}><DashboardCard 
+              cardType={'danger'} 
+              title="Failures Avg" 
+              body={prowJobsStats?.jobs != null ? (100 * prowJobsStats.jobs[selectedJob].summary.failure_count / prowJobsStats.jobs[selectedJob].summary.total_jobs).toFixed(2) + "%" : "-"}
+              subtext={prowJobsStats?.jobs != null ? prowJobsStats.jobs[selectedJob].summary.failure_count + "/" + prowJobsStats.jobs[selectedJob].summary.total_jobs : "-" }
+              ></DashboardCard></GridItem>
+
+              <GridItem span={2}><DashboardCard 
+              cardType={'success'} 
+              title="Passed Tests Avg" 
+              body={prowJobsStats?.jobs != null ? (100 * prowJobsStats.jobs[selectedJob].summary.success_count / prowJobsStats.jobs[selectedJob].summary.total_jobs).toFixed(2) + "%" : "-"}
+              subtext={prowJobsStats?.jobs != null ? prowJobsStats.jobs[selectedJob].summary.success_count + "/" + prowJobsStats.jobs[selectedJob].summary.total_jobs : "-" }
+              ></DashboardCard></GridItem>
+
+              <GridItem span={3}><DashboardCard 
+              cardType={'default'} 
+              title="Total CI Jobs Executed" 
+              body={prowJobsStats?.jobs != null ? prowJobsStats.jobs[selectedJob].summary.total_jobs.toString() : "N/A"}
+              subtext=""
+              ></DashboardCard></GridItem>
+
               <GridItem span={4} rowSpan={4}><DashboardSimpleList title={<div>Jobs  <a href={ci_html} target="blank" rel="noopener noreferrer"><Badge style={{ float: "right" }}>{jobType} &nbsp; <ExternalLinkAltIcon></ExternalLinkAltIcon></Badge></a></div>} data={jobNames} onSelection={(value) => { setSelectedJob(value) }}></DashboardSimpleList></GridItem>
               <GridItem span={8} rowSpan={5}><DashboardLineChart data={beautifiedData}></DashboardLineChart></GridItem>
-              <GridItem span={4} rowSpan={1}><DashboardCard cardType={'help'} title="About this dashboard" body="Set of metrics gathered from Openshift CI"></DashboardCard></GridItem>
+              <GridItem span={4} rowSpan={1}><DashboardCard cardType={'help'} title="About this dashboard" body="Set of metrics gathered from Openshift CI" subtext=""></DashboardCard></GridItem>
 
               {prowJobs != null && <GridItem span={12}>
                 <FailedE2ETests failedProwJobs={getFailedProwJobsInE2ETests(prowJobs, jobType)} jobType={jobType}></FailedE2ETests>

--- a/frontend/src/app/utils/sharedComponents.tsx
+++ b/frontend/src/app/utils/sharedComponents.tsx
@@ -24,18 +24,19 @@ export interface JobsEntity {
 }
 
 export interface MetricsSummary {
-  success_rate_avg: string;
-  failure_rate_avg: string;
-  ci_failed_rate_avg: string;
+  success_count: number;
+  failure_count: number;
+  ci_failed_count: number;
   date_from: string;
   date_to: string;
   total_jobs: number;
 }
 
 export interface MetricsEntity {
-  success_rate: string;
-  failure_rate: string;
-  ci_failed_rate: string;
+  success_count: number;
+  failure_count: number;
+  ci_failed_count: number;
+  total_jobs: number;
   date: string;
 }
 
@@ -222,9 +223,10 @@ export type DashboardCardProps = {
   cardType?: 'default' | 'danger' | 'success' | 'warning' | 'primary' | 'help';
   title: string;
   body: string;
+  subtext: string;
 };
 
-export const DashboardCard = ({ cardType, title, body }: DashboardCardProps) => {
+export const DashboardCard = ({ cardType, title, body, subtext}: DashboardCardProps) => {
   const cardStyle = new Map();
   cardStyle.set('title-danger', { color: "#A30000", fontWeight: "semibold", fontSize: "0.8em" });
   cardStyle.set('title-success', { color: "#1E4F18", fontWeight: "semibold", fontSize: "0.8em" });
@@ -238,6 +240,12 @@ export const DashboardCard = ({ cardType, title, body }: DashboardCardProps) => 
   cardStyle.set('body-default', { color: "black", fontWeight: "bold", fontSize: "1.8em", textAlign: "center" });
   cardStyle.set('body-help', { color: "grey", fontWeight: "normal", fontSize: "0.8em", textAlign: "left" });
   cardStyle.set('body-primary', { color: "#0066CC", fontWeight: "bold", fontSize: "2em", textAlign: "center" });
+  cardStyle.set('subtext-danger', { color: "#A30000", fontWeight: "normal", fontSize: "0.7em", textAlign: "center" });
+  cardStyle.set('subtext-success', { color: "#1E4F18", fontWeight: "normal", fontSize: "0.7em", textAlign: "center" });
+  cardStyle.set('subtext-warning', { color: "#F0AB00", fontWeight: "normal", fontSize: "0.7em", textAlign: "center" });
+  cardStyle.set('subtext-default', { color: "black", fontWeight: "normal", fontSize: "0.7em", textAlign: "center" });
+  cardStyle.set('subtext-help', { color: "grey", fontWeight: "normal", fontSize: "0.8em", textAlign: "left" });
+  cardStyle.set('subtext-primary', { color: "#0066CC", fontWeight: "bold", fontSize: "1em", textAlign: "center" });
 
   return (
     <Card style={{ width: "100%", height: "100%" }}>
@@ -249,6 +257,10 @@ export const DashboardCard = ({ cardType, title, body }: DashboardCardProps) => 
         {body}
         {cardType == 'danger' && <ExclamationCircleIcon style={{ fontSize: "1.2rem", margin: "0 5px" }}></ExclamationCircleIcon>}
         {cardType == 'success' && <OkIcon style={{ fontSize: "1.2rem", margin: "0 5px" }}></OkIcon>}
+
+        <div style={cardStyle.get("subtext-" + cardType)}>
+          {subtext}
+        </div>
       </CardBody>
     </Card>
   )


### PR DESCRIPTION
This PR adds whole numbers under percentages to cards in OpenShift CI Test Report Page.

Issue:
[AD-108](https://issues.redhat.com/browse/AD-108)

New OpenShift CI Test Report Page look:
![Screenshot_20231108_124054](https://github.com/redhat-appstudio/quality-dashboard/assets/124383262/b8ad64d8-1840-4d4e-bdb2-af912da2f1bb)
