### PR TITLE
[AD-102] Add count of Merged/Created PRs on GitHub Page

### DIFF
--- a/backend/api/apis/github/v1alpha1/prs.go
+++ b/backend/api/apis/github/v1alpha1/prs.go
@@ -67,11 +67,17 @@ type ListPullRequestsOptions struct {
 
 // Summary represents all the collected information regarding all the pull requests of a repository.
 type Summary struct {
-	// Number of merged pull requests.
-	MergedPrsCount int `json:"merged_prs"`
+	// Number of open pull requests.
+	CreatedPrsCountInTimeRange int `json:"created_prs_in_time_range"`
 
 	// Number of open pull requests.
 	OpenPrsCount int `json:"open_prs"`
+
+	// Number of merged pull requests.
+	MergedPrsCount int `json:"merged_prs"`
+
+	// Number of merged pull requests.
+	MergedPrsCountInTimeRange int `json:"merged_prs_in_time_range"`
 
 	// Average time to merge a pull request.
 	MergeAvg float64 `json:"merge_avg"`

--- a/backend/api/apis/github/v1alpha1/prs.go
+++ b/backend/api/apis/github/v1alpha1/prs.go
@@ -67,7 +67,7 @@ type ListPullRequestsOptions struct {
 
 // Summary represents all the collected information regarding all the pull requests of a repository.
 type Summary struct {
-	// Number of open pull requests.
+	// Number of created pull requests.
 	CreatedPrsCountInTimeRange int `json:"created_prs_in_time_range"`
 
 	// Number of open pull requests.

--- a/frontend/src/app/Github/Github.tsx
+++ b/frontend/src/app/Github/Github.tsx
@@ -46,8 +46,10 @@ export interface RepositoryInfo {
   coverage_trend: string,
   retest_avg: string;
   retest_before_merge_avg: string;
+  created_prs_in_time_range: string;
   open_prs: string;
   merged_prs: string;
+  merged_prs_in_time_range: string;
   time_to_merge_pr_avg_days: string;
 }
 
@@ -90,8 +92,10 @@ let GitHub = () => {
           // https://github.com/redhat-appstudio/service-provider-integration-operator/pull/548#issuecomment-1494149514
           retest_avg: repository.prs?.summary.retest_avg == 0 || repository.prs?.summary.retest_avg == 0.01 ? 'N/A' : repository.prs?.summary.retest_avg,
           retest_before_merge_avg: repository.prs?.summary.retest_before_merge_avg == 0 || repository.prs?.summary.retest_before_merge_avg == 0.01 ? 'N/A' : repository.prs?.summary.retest_before_merge_avg,
+          created_prs_in_time_range: repository.prs?.summary?.created_prs_in_time_range,
           open_prs: repository.prs?.summary?.open_prs,
           merged_prs: repository.prs?.summary?.merged_prs,
+          merged_prs_in_time_range: repository.prs?.summary?.merged_prs_in_time_range,
           time_to_merge_pr_avg_days: repository.prs?.summary?.merge_avg + ' day(s)',
         });
       })
@@ -144,8 +148,10 @@ let GitHub = () => {
               // https://github.com/redhat-appstudio/service-provider-integration-operator/pull/548#issuecomment-1494149514
               retest_avg: repository.prs?.summary.retes_avg == 0 || repository.prs?.summary.retest_avg == 0.01 ? 'N/A' : repository.prs?.summary.retest_avg,
               retest_before_merge_avg: repository.prs?.summary.retest_before_merge_avg == 0 || repository.prs?.summary.retest_before_merge_avg == 0.01 ? 'N/A' : repository.prs?.summary.retest_before_merge_avg,
+              created_prs_in_time_range: repository.prs?.summary?.created_prs_in_time_range,
               open_prs: repository.prs?.summary?.open_prs,
               merged_prs: repository.prs?.summary?.merged_prs,
+              merged_prs_in_time_range: repository.prs?.summary?.merged_prs_in_time_range,
               time_to_merge_pr_avg_days: repository.prs?.summary?.merge_avg + ' day(s)',
             });
           })

--- a/frontend/src/app/Github/Metrics.tsx
+++ b/frontend/src/app/Github/Metrics.tsx
@@ -68,11 +68,7 @@ export const GetMetrics = () => {
                     </GridItem>
 
                     <GridItem span={2} rowSpan={1}>
-                        <PullRequestCard
-                            title="Time To Merge PR Avg Days"
-                            subtitle="Selected Time Range"
-                            total={prs?.summary?.merge_avg}
-                        ></PullRequestCard>
+                        <PullRequestCard title="Time To Merge PR Avg Days" subtitle="Selected Time Range" total={prs?.summary?.merge_avg}></PullRequestCard>
                     </GridItem>
 
                     <GridItem span={2} rowSpan={1}>
@@ -83,8 +79,12 @@ export const GetMetrics = () => {
                         ></PullRequestCard>
                     </GridItem>
 
-                    <GridItem span={3} rowSpan={1}>
+                    <GridItem span={2} rowSpan={1}>
                         <PullRequestCard title="Open PRs" subtitle="Total" total={prs?.summary?.open_prs}></PullRequestCard>
+                    </GridItem>
+
+                    <GridItem span={1} rowSpan={1}>
+                        <PullRequestCard title="Created PRs" subtitle="Selected Time Range" total={prs?.summary?.created_prs_in_time_range}></PullRequestCard>
                     </GridItem>
 
                     <GridItem span={2} rowSpan={1}>
@@ -97,12 +97,12 @@ export const GetMetrics = () => {
                         ></PullRequestCard>
                     </GridItem>
 
-                    <GridItem span={3} rowSpan={1}>
-                        <PullRequestCard
-                            title="Merged PRs"
-                            subtitle="Total"
-                            total={prs?.summary?.merged_prs}
-                        ></PullRequestCard>
+                    <GridItem span={2} rowSpan={1}>
+                        <PullRequestCard title="Merged PRs" subtitle="Total" total={prs?.summary?.merged_prs}></PullRequestCard>
+                    </GridItem>
+                    
+                    <GridItem span={1} rowSpan={1}>
+                        <PullRequestCard title="Merged PRs" subtitle="Selected Time Range" total={prs?.summary?.merged_prs_in_time_range}></PullRequestCard>
                     </GridItem>
 
                     <GridItem span={2} rowSpan={1}>

--- a/frontend/src/app/Github/PullRequests.tsx
+++ b/frontend/src/app/Github/PullRequests.tsx
@@ -64,6 +64,12 @@ export const PullRequestCard = (props) => {
           {props.title == 'Retest Avg in Open PRs' && (
             help("Average retests in open PRs: calculate an average how many /test and /retest comments were in total issued for pull requests opened in selected time range")
           )}
+          {props.title == 'Created PRs' && (
+            help("Count of created PRs: count of all PRs created in the selected time range")
+          )}
+          {props.title == 'Merged PRs' && props.subtitle == 'Selected Time Range' && (
+            help("Count of merged PRs: count of all PRs merged in the selected time range")
+          )}
           {props.title == 'Retest Before Merge Avg' && (
             help("Retests to merge: calculate an average how many /test and /retest comments were issued after the last code push")
           )}


### PR DESCRIPTION
This PR adds tiles with counts of created and merged PRs in selected time range to the Github page.

Issue:
[AD-102](https://issues.redhat.com/browse/AD-102)

New Github Metrics page look:
![Screenshot_20231110_150345](https://github.com/redhat-appstudio/quality-dashboard/assets/124383262/83ae0f9c-1d72-4cfa-9e28-6c6391abe815)
