### PR TITLE
AD-134 - Exclude weekend days in SLIs for Triage and Response Time

### DIFF
--- a/backend/pkg/storage/ent/client/jira_bugs.go
+++ b/backend/pkg/storage/ent/client/jira_bugs.go
@@ -412,6 +412,7 @@ func (d *Database) getJiraBugMetrics(bug jira.Issue) JiraBugMetricsInfo {
 
 	createdTime := time.Time(bug.Fields.Created).UTC()
 	daysSinceCreation := getDaysBetweenDates(createdTime, time.Now().UTC())
+	businessDaysSinceCreation := getBusinessDays(createdTime, time.Now().UTC())
 
 	if bug.Fields.Status.Name == "Closed" || bug.Fields.Status.Name == "Resolved" || bug.Fields.Status.Name == "Done" {
 		// issue was closed
@@ -459,12 +460,12 @@ func (d *Database) getJiraBugMetrics(bug jira.Issue) JiraBugMetricsInfo {
 
 	// assignee was not defined
 	if bug.Fields.Assignee == nil {
-		jiraBugMetric.DaysWithoutAssignee = daysSinceCreation
+		jiraBugMetric.DaysWithoutAssignee = businessDaysSinceCreation
 	}
 
 	// priority was not defined
 	if bug.Fields.Priority == nil || bug.Fields.Priority.Name == "Undefined" {
-		jiraBugMetric.DaysWithoutPriority = daysSinceCreation
+		jiraBugMetric.DaysWithoutPriority = businessDaysSinceCreation
 	}
 
 	return jiraBugMetric

--- a/backend/pkg/storage/ent/client/utils.go
+++ b/backend/pkg/storage/ent/client/utils.go
@@ -94,3 +94,27 @@ func getDaysBetweenDates(firstDate, secondDate time.Time) float64 {
 
 	return diff
 }
+
+// getBusinessDays only includes business days by excluding weekend days
+func getBusinessDays(fromDate, toDate time.Time) float64 {
+	var businessDays float64 = 0
+	previousDate := fromDate
+	nextDate := previousDate.Add(time.Hour * 24)
+
+	for {
+		if previousDate.Equal(toDate) || previousDate.Equal(nextDate) || previousDate.After(toDate) || previousDate.After(nextDate) {
+			break
+		}
+		if previousDate.Weekday() != 6 && previousDate.Weekday() != 0 {
+			if toDate.Before(nextDate) {
+				businessDays += getDaysBetweenDates(previousDate, toDate)
+			} else {
+				businessDays += getDaysBetweenDates(previousDate, nextDate)
+			}
+		}
+		previousDate = nextDate
+		nextDate = previousDate.Add(time.Hour * 24)
+	}
+
+	return businessDays
+}


### PR DESCRIPTION
# Description

- Exclude weekend days in SLIs for Triage and Response Time

**Triage Time Bug SLI**: Priority should not be undefined for more than 2 days on untriaged bugs
**Response Time Bug SLI**: Assignee should not be undefined for more than 2 days on Blocker and Critical bugs


Currently, SLIs for Triage and Response Time are considered the weekend days.
If an issue is opened on Friday and does not meet the defined Bug SLOs on that day, the teams will see the alert on Monday reporting that they do not meet the Bug SLOs (because the SLIs are short. In these cases, 2 days). However, they should not been alert since they did not have 2 working days to address the SLOs.
To avoid it, we should skip weekends in SLIs for Triage and Response Time metrics.


## Issue ticket number and link
[AD-134](https://issues.redhat.com/browse/AD-134)