### PR TITLE
AD-137 - Use only working days in all metrics in the Bug SLOs

### DIFF
--- a/backend/pkg/storage/ent/client/jira_bugs.go
+++ b/backend/pkg/storage/ent/client/jira_bugs.go
@@ -411,8 +411,7 @@ func (d *Database) getJiraBugMetrics(bug jira.Issue) JiraBugMetricsInfo {
 	}
 
 	createdTime := time.Time(bug.Fields.Created).UTC()
-	daysSinceCreation := getDaysBetweenDates(createdTime, time.Now().UTC())
-	businessDaysSinceCreation := getBusinessDays(createdTime, time.Now().UTC())
+	workingDaysSinceCreation := getWorkingDays(createdTime, time.Now().UTC())
 
 	if bug.Fields.Status.Name == "Closed" || bug.Fields.Status.Name == "Resolved" || bug.Fields.Status.Name == "Done" {
 		// issue was closed
@@ -420,7 +419,7 @@ func (d *Database) getJiraBugMetrics(bug jira.Issue) JiraBugMetricsInfo {
 		jiraBugMetric.BugIsResolved = true
 	} else {
 		// issue was not resolved
-		jiraBugMetric.DaysWithoutResolution = daysSinceCreation
+		jiraBugMetric.DaysWithoutResolution = workingDaysSinceCreation
 	}
 
 	foundFirstAssignee := false
@@ -460,12 +459,12 @@ func (d *Database) getJiraBugMetrics(bug jira.Issue) JiraBugMetricsInfo {
 
 	// assignee was not defined
 	if bug.Fields.Assignee == nil {
-		jiraBugMetric.DaysWithoutAssignee = businessDaysSinceCreation
+		jiraBugMetric.DaysWithoutAssignee = workingDaysSinceCreation
 	}
 
 	// priority was not defined
 	if bug.Fields.Priority == nil || bug.Fields.Priority.Name == "Undefined" {
-		jiraBugMetric.DaysWithoutPriority = businessDaysSinceCreation
+		jiraBugMetric.DaysWithoutPriority = workingDaysSinceCreation
 	}
 
 	return jiraBugMetric

--- a/backend/pkg/storage/ent/client/utils.go
+++ b/backend/pkg/storage/ent/client/utils.go
@@ -87,9 +87,9 @@ func getDaysBetweenDates(firstDate, secondDate time.Time) float64 {
 	return diff
 }
 
-// getBusinessDays only includes business days by excluding weekend days
-func getBusinessDays(fromDate, toDate time.Time) float64 {
-	var businessDays float64 = 0
+// getWorkingDays only includes business days by excluding weekend days
+func getWorkingDays(fromDate, toDate time.Time) float64 {
+	var workingDays float64 = 0
 	previousDate := fromDate
 	nextDate := previousDate.Add(time.Hour * 24)
 
@@ -99,14 +99,14 @@ func getBusinessDays(fromDate, toDate time.Time) float64 {
 		}
 		if previousDate.Weekday() != 6 && previousDate.Weekday() != 0 {
 			if toDate.Before(nextDate) {
-				businessDays += getDaysBetweenDates(previousDate, toDate)
+				workingDays += getDaysBetweenDates(previousDate, toDate)
 			} else {
-				businessDays += getDaysBetweenDates(previousDate, nextDate)
+				workingDays += getDaysBetweenDates(previousDate, nextDate)
 			}
 		}
 		previousDate = nextDate
 		nextDate = previousDate.Add(time.Hour * 24)
 	}
 
-	return businessDays
+	return workingDays
 }

--- a/frontend/src/app/BugSLIs/Table.tsx
+++ b/frontend/src/app/BugSLIs/Table.tsx
@@ -10,6 +10,7 @@ import {
     ThProps,
 } from '@patternfly/react-table';
 import { Bug } from './Types';
+import { fillPopOver } from '@app/Github/Table';
 
 export const OverviewTable: React.FC<{ bugSLIs: Array<Bug>, selected: string }> = ({ bugSLIs, selected }) => {
     const [bugSLIsPage, setBugSLIsPage] = useState<Array<Bug>>([]);
@@ -203,6 +204,12 @@ export const OverviewTable: React.FC<{ bugSLIs: Array<Bug>, selected: string }> 
             return "#FAEE84"
         }
     }
+    const getInfo = (label) => {
+        if (label == 'Days Without Assignment' || label == 'Days Without Prioritization' || label == 'Days Without Resolution') {
+            return fillPopOver(label, "Only considers working days.")
+        }
+        return
+    }
 
     return (
         <div>
@@ -226,6 +233,7 @@ export const OverviewTable: React.FC<{ bugSLIs: Array<Bug>, selected: string }> 
                                     width={10}
                                     sort={getSortParams(idx)}
                                     key={idx}
+                                    info={getInfo(column.label)}
                                 >
                                     <div>
                                         {column.label}


### PR DESCRIPTION
# Description

- Currently, the Resolution Time Bug SLO metric is not considering only working days. We should change it in order to align with Response Time Bug SLO and Triage Time Bug SLO metrics that already consider only working days.


## Issue ticket number and link
[AD-137](https://issues.redhat.com/browse/AD-137)