### PR TITLE
Update gcs bucket name

### DIFF
--- a/backend/pkg/connectors/gcs/gcs_authentication.go
+++ b/backend/pkg/connectors/gcs/gcs_authentication.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/api/option"
 )
 
-const OpenshiCiBucketName = "origin-ci-test"
+const OpenshiCiBucketName = "test-platform-results"
 
 type GCSBucket struct {
 	// retrieval mechanisms


### PR DESCRIPTION
GCS bucket name for ci jobs has changed. This PR should update it to the new correct one. ([thread](https://redhat-internal.slack.com/archives/CFUGK0K9R/p1702999988408109))