### PR TITLE
AD-167 -  konflux bug slis

### DIFF
--- a/backend/api/server/rhtap_bug_slis_alert.go
+++ b/backend/api/server/rhtap_bug_slis_alert.go
@@ -64,10 +64,7 @@ func getMessage(alert jira.Alert, alertType string) string {
 	return ""
 }
 
-func (s *Server) sendAlert(team, msg, color string) {
-	// channel: rhtap-bug-slis-alerts
-	channelID := "C062AF1RFK8"
-
+func (s *Server) sendAlert(team, msg, color, channelID string) {
 	// get team mention
 	mention := getMention(team)
 
@@ -114,18 +111,17 @@ func slisByTeam(bugs []jira.Bug) []Team {
 }
 
 func (s *Server) sendAlerts() {
-	// startDate := time.Now().AddDate(-2, 0, 0).Format(constants.DateFormat)
-	// toDate := time.Now().Format(constants.DateFormat)
-
-	// bugs, err := s.cfg.Storage.GetAllOpenRHTAPBUGS(startDate, toDate)
-
-	bugs, err := s.cfg.Storage.GetAllOpenRHTAPBUGSForSliAlerts()
+	// only for KFLUXBUGS for now
+	bugs, err := s.cfg.Storage.GetAllOpenBugsForSliAlerts("KFLUXBUGS")
 	if err != nil {
 		s.cfg.Logger.Sugar().Errorf("Failed to get all open RHTAP Bug SLOs", zap.Error(err))
 	}
 
 	slis := jira.GetBugSLIs(bugs)
 	teams := slisByTeam(slis.Bugs)
+
+	// channel: konflux-bug-slis-alerts
+	channelID := "C062AF1RFK8"
 
 	for _, team := range teams {
 		redMsg := ""
@@ -147,15 +143,15 @@ func (s *Server) sendAlerts() {
 		}
 
 		if redMsg != "" {
-			s.sendAlert(team.ComponentName, redMsg, "#FF0000")
+			s.sendAlert(team.ComponentName, redMsg, "#FF0000", channelID)
 		}
 
 		if componentAssignmentMsg != "" {
-			s.sendAlert("ic-appstudio-qe", componentAssignmentMsg, "#FF0000")
+			s.sendAlert("ic-appstudio-qe", componentAssignmentMsg, "#FF0000", channelID)
 		}
 
 		if yellowMsg != "" {
-			s.sendAlert(team.ComponentName, yellowMsg, "#FFFF00")
+			s.sendAlert(team.ComponentName, yellowMsg, "#FFFF00", channelID)
 		}
 
 	}

--- a/backend/api/server/router/jira/jira.go
+++ b/backend/api/server/router/jira/jira.go
@@ -331,8 +331,8 @@ func (s *jiraRouter) getBugSLIs(ctx context.Context, w http.ResponseWriter, r *h
 	// 	})
 	// }
 
-	// bugs, err := s.Storage.GetAllOpenRHTAPBUGS(startDate[0], endDate[0])
-	bugs, err := s.Storage.GetAllOpenRHTAPBUGS()
+	// bugs, err := s.Storage.GetAllOpenBugs(startDate[0], endDate[0])
+	bugs, err := s.Storage.GetAllOpenBugs("KFLUXBUGS")
 	if err != nil {
 		return httputils.WriteJSON(w, http.StatusInternalServerError, &types.ErrorResponse{
 			Message:    err.Error(),

--- a/backend/pkg/storage/ent/client/jira_bugs.go
+++ b/backend/pkg/storage/ent/client/jira_bugs.go
@@ -499,12 +499,12 @@ func (d *Database) getJiraBugMetrics(bug jira.Issue) JiraBugMetricsInfo {
 	return jiraBugMetric
 }
 
-// GetAllOpenRHTAPBUGS gets all the RHTAPBUGS that are open
-// func (d *Database) GetAllOpenRHTAPBUGS(dateFrom, dateTo string) ([]*db.Bugs, error) {
-func (d *Database) GetAllOpenRHTAPBUGS() ([]*db.Bugs, error) {
+// GetAllOpenBugs gets all the bugs that are open for the given project
+// func (d *Database) GetAllOpenBugs(dateFrom, dateTo string) ([]*db.Bugs, error) {
+func (d *Database) GetAllOpenBugs(project string) ([]*db.Bugs, error) {
 	b, err := d.client.Bugs.Query().
 		Where(predicate.Bugs(bugs.Resolved(false))).
-		Where(predicate.Bugs(bugs.ProjectKey("RHTAPBUGS"))).
+		Where(predicate.Bugs(bugs.ProjectKey(project))).
 		All(context.TODO())
 
 	if err != nil {
@@ -514,12 +514,12 @@ func (d *Database) GetAllOpenRHTAPBUGS() ([]*db.Bugs, error) {
 	return b, nil
 }
 
-// GetAllOpenRHTAPBUGSForSliAlerts gets all the RHTAPBUGS that are open
+// GetAllOpenBugsForSliAlerts gets all the bugs that are open for the given project
 // except bugs with status as "Waiting" or "Release Pending"
-func (d *Database) GetAllOpenRHTAPBUGSForSliAlerts() ([]*db.Bugs, error) {
+func (d *Database) GetAllOpenBugsForSliAlerts(project string) ([]*db.Bugs, error) {
 	b, err := d.client.Bugs.Query().
 		Where(predicate.Bugs(bugs.StatusNotIn("Waiting", "Release Pending", "Closed"))).
-		Where(predicate.Bugs(bugs.ProjectKey("RHTAPBUGS"))).
+		Where(predicate.Bugs(bugs.ProjectKey(project))).
 		All(context.TODO())
 
 	if err != nil {

--- a/backend/pkg/storage/storage.go
+++ b/backend/pkg/storage/storage.go
@@ -46,9 +46,9 @@ type Storage interface {
 	GetJobsNameAndType(repo *db.Repository) ([]*db.ProwJobs, error)
 	GetMetricsSummaryByDay(repo *db.Repository, job, startDate, endDate string) []*prowV1Alpha1.JobsMetrics
 
-	// GetAllOpenRHTAPBUGS(dateFrom, dateTo string) ([]*db.Bugs, error)
-	GetAllOpenRHTAPBUGS() ([]*db.Bugs, error)
-	GetAllOpenRHTAPBUGSForSliAlerts() ([]*db.Bugs, error)
+	// GetAllOpenBugs(dateFrom, dateTo string) ([]*db.Bugs, error)
+	GetAllOpenBugs(project string) ([]*db.Bugs, error)
+	GetAllOpenBugsForSliAlerts(project string) ([]*db.Bugs, error)
 	GetPullRequestsByRepository(repositoryName, organization, startDate, endDate string) (repoV1Alpha1.PullRequestsInfo, error)
 	GetFrequency(team *db.Teams, errorMessage, startDate, endDate string) (float64, error)
 	GetJiraBug(key string) (*db.Bugs, error)

--- a/frontend/src/app/BugSLIs/MainPage.tsx
+++ b/frontend/src/app/BugSLIs/MainPage.tsx
@@ -151,10 +151,10 @@ export const BugSLIs = () => {
     return (
         <React.Fragment>
             {/* page title bar */}
-            <Header info="Observe which RHTAPBUGS issues are not meeting the defined Bug SLOs."></Header>
+            <Header info="Observe which KFLUXBUGS issues are not meeting the defined Bug SLOs."></Header>
             <PageSection variant={PageSectionVariants.light}>
                 <Title headingLevel="h3" size={TitleSizes['2xl']}>
-                    Bug SLIs (RHTAPBUGS only)
+                    Bug SLIs (KFLUXBUGS only)
                     <Button
                         onClick={() => navigator.clipboard.writeText(window.location.href)}
                         variant="link"

--- a/frontend/src/app/utils/APIService.ts
+++ b/frontend/src/app/utils/APIService.ts
@@ -397,7 +397,7 @@ async function getJobNamesAndTypes(repoName: string, repoOrg: string) {
     throw 'Error fetching data from server. ';
   }
 
-  if(!result.data) {
+  if (!result.data) {
     throw 'No jobs detected in OpenShift CI';
   }
 


### PR DESCRIPTION
# Description
At the moment, bug slis alerts are only available for RHTAPBUGS. Since we will need also KFLUXBUGS, we will need to address it. So, in the short term, we will need to:
- rename the channel [#rhtap-bug-slis-alerts](https://redhat-internal.slack.com/archives/C062AF1RFK8) to konflux-bug-slis-alerts
- update the plugin to look only at the KFLUXBUGS project

## Issue ticket number and link
[AD-167](https://issues.redhat.com/browse/AD-167)