### PR TITLE
AD-171: split bulk when creating a large number of jira bugs

### DIFF
--- a/backend/api/server/rotate.go
+++ b/backend/api/server/rotate.go
@@ -73,7 +73,7 @@ func (s *Server) rotate() error {
 
 func staticRotationStrategy() rotationStrategy {
 	return rotationStrategy{
-		rotationFrequency: time.Second * 10,
+		rotationFrequency: time.Minute * 40,
 	}
 }
 
@@ -89,8 +89,10 @@ func shouldBeDeleted(jiraKey string, bugs []jira.Issue) bool {
 func (s *Server) rotateJiraBugs(jiraKeys string, team *db.Teams) error {
 	bugs := s.cfg.Jira.GetBugsByJQLQuery(fmt.Sprintf("project in (%s) AND type = Bug", team.JiraKeys))
 	if err := s.cfg.Storage.CreateJiraBug(bugs, team); err != nil {
+		fmt.Println("err", err)
 		return err
 	}
+	fmt.Println("terminou")
 
 	projects := strings.Split(team.JiraKeys, ",")
 	bugsInDb := make([]*db.Bugs, 0)

--- a/backend/api/server/rotate.go
+++ b/backend/api/server/rotate.go
@@ -89,10 +89,8 @@ func shouldBeDeleted(jiraKey string, bugs []jira.Issue) bool {
 func (s *Server) rotateJiraBugs(jiraKeys string, team *db.Teams) error {
 	bugs := s.cfg.Jira.GetBugsByJQLQuery(fmt.Sprintf("project in (%s) AND type = Bug", team.JiraKeys))
 	if err := s.cfg.Storage.CreateJiraBug(bugs, team); err != nil {
-		fmt.Println("err", err)
 		return err
 	}
-	fmt.Println("terminou")
 
 	projects := strings.Split(team.JiraKeys, ",")
 	bugsInDb := make([]*db.Bugs, 0)

--- a/backend/pkg/storage/ent/client/jira_bugs.go
+++ b/backend/pkg/storage/ent/client/jira_bugs.go
@@ -55,7 +55,6 @@ func getComponent(components []*jira.Component) string {
 
 // CreateJiraBug saves provided jira bugs information in database.
 func (d *Database) CreateJiraBug(bugsArr []jira.Issue, team *db.Teams) error {
-	fmt.Println(team)
 	bulkSize := 2000
 
 	if len(bugsArr) > bulkSize {

--- a/backend/pkg/storage/ent/client/jira_bugs.go
+++ b/backend/pkg/storage/ent/client/jira_bugs.go
@@ -55,6 +55,33 @@ func getComponent(components []*jira.Component) string {
 
 // CreateJiraBug saves provided jira bugs information in database.
 func (d *Database) CreateJiraBug(bugsArr []jira.Issue, team *db.Teams) error {
+	fmt.Println(team)
+	bulkSize := 2000
+
+	if len(bugsArr) > bulkSize {
+		// number of issues is too high
+		// probably will hit a similar error like: 'Update failed: insert nodes to table "bugs": pq: got 554645 parameters but PostgreSQL only supports 65535 parameters'
+		// we will need to split in smaller bulks
+		for start := 0; start < len(bugsArr); start += bulkSize {
+			end := start + bulkSize
+			if end > len(bugsArr) {
+				end = len(bugsArr)
+			}
+
+			err := d.CreateBug(bugsArr[start:end], team)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	err := d.CreateBug(bugsArr, team)
+	return err
+}
+
+// CreateBug saves provided jira bugs information in database.
+func (d *Database) CreateBug(bugsArr []jira.Issue, team *db.Teams) error {
 	create := false
 	createBulk := make([]*db.BugsCreate, 0)
 	for _, bug := range bugsArr {

--- a/frontend/src/app/Jira/utils.tsx
+++ b/frontend/src/app/Jira/utils.tsx
@@ -39,7 +39,7 @@ export const getIssuesByField = (issues: Issue[], label: string, field: string) 
         };
     }).filter(
         (elem, index, arr) => index === arr.findIndex((t) => t.x === elem.x)
-    );
+    ).filter(element => element.y != 0);
 
     return issuesByField
 }


### PR DESCRIPTION
# Description
The Jira page is empty for DevConsole team with OCPBUGS as project because this project has a lot of issues. 
GetBugsByJQLQuery function is failing with:

`2024-02-12T09:05:05.726Z        info    server/rotate.go:31      Update failed: insert nodes to table "bugs": pq: got 646231 parameters but PostgreSQL only supports 65535 parameters`

So, we need to split the bulks when creating issues.

## Issue ticket number and link
[AD-171](https://issues.redhat.com/browse/AD-171)