### PR TITLE
AD-175: CI Impact of a bug should be available for any team’s project

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,10 +233,10 @@ As the first step, we need to know how many days the issues have not been resolv
 Then, we need to use the information above to get the issues that are not meeting or almost not meeting the defined SLIs. For that, we defined a [function to get each SLI](https://github.com/redhat-appstudio/quality-dashboard/blob/main/backend/api/server/router/jira/bug_slos.go).
 
 
-### RHTAPBUGS Impact on CI
+### Bug CI Impact
 
 #### Description
-RHTAPBUGS Impact on CI plugin lists the RHTAPBUGS that are impacting CI, by showing the Jira Key, Jira Status, Error Message, and Frequency. You can add, update, or delete them.
+Bug CI Impact metrics lists the bugs that are impacting CI, by showing the Jira Key, Jira Status, Error Message, and Frequency. You can add, update, or delete them.
 To add a new entry, you need to point out the Jira Key of the bug and the associated error message.
 
 #### How the frequency/impact is being measured?

--- a/backend/api/server/router/jira/jira.go
+++ b/backend/api/server/router/jira/jira.go
@@ -306,7 +306,7 @@ func (s *jiraRouter) bugExists(ctx context.Context, w http.ResponseWriter, r *ht
 	if err != nil {
 		s.Logger.Error("Failed to check if jira key exists")
 
-		return httputils.WriteJSON(w, http.StatusInternalServerError, &types.ErrorResponse{
+		return httputils.WriteJSON(w, http.StatusBadRequest, &types.ErrorResponse{
 			Message:    err.Error(),
 			StatusCode: http.StatusBadRequest,
 		})

--- a/backend/pkg/storage/ent/client/jira_bugs.go
+++ b/backend/pkg/storage/ent/client/jira_bugs.go
@@ -58,7 +58,6 @@ func (d *Database) CreateJiraBug(bugsArr []jira.Issue, team *db.Teams) error {
 	bulkSize := 2000
 
 	if len(bugsArr) > bulkSize {
-		fmt.Printf("project %s has a lot of issues. we need to split", team.JiraKeys)
 		// number of issues is too high
 		// probably will hit a similar error like: 'Update failed: insert nodes to table "bugs": pq: got 554645 parameters but PostgreSQL only supports 65535 parameters'
 		// we will need to split in smaller bulks

--- a/frontend/src/app/AppLayout/AppLayout.tsx
+++ b/frontend/src/app/AppLayout/AppLayout.tsx
@@ -122,7 +122,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
 
 
   const toRender = (label) => {
-    if (label == "Plugins") {
+    if (label == "Metrics") {
       getVersion().then(res => {
         if (!(res.code == 200)) {
           setServerUnavailable(true)

--- a/frontend/src/app/CiFailures/CiFailures.tsx
+++ b/frontend/src/app/CiFailures/CiFailures.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { CopyIcon, PlusIcon } from '@patternfly/react-icons';
+import { CopyIcon, OpenDrawerRightIcon, PlusIcon } from '@patternfly/react-icons';
 import {
   PageSection,
   PageSectionVariants,
@@ -12,6 +12,13 @@ import {
   CardBody,
   Flex,
   FlexItem,
+  Drawer,
+  DrawerContent,
+  DrawerPanelContent,
+  DrawerHead,
+  DrawerActions,
+  DrawerCloseButton,
+  TextContent,
 } from '@patternfly/react-core';
 import { Button } from '@patternfly/react-core';
 import { Grid, GridItem } from '@patternfly/react-core';
@@ -48,6 +55,8 @@ let CiFailures = () => {
   const [rangeDateTime, setRangeDateTime] = useState(getRangeDates(15));
   const [failures, setFailures] = useState<any>({});
   const history = useHistory();
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const drawerRef = React.useRef<HTMLDivElement>();
 
   function handleChange(event, from, to) {
     setRangeDateTime([from, to]);
@@ -133,14 +142,47 @@ let CiFailures = () => {
     modalContext.handleModalToggle()
   }
 
+  const onCloseClick = () => {
+    setIsExpanded(false);
+  };
+
+  const onLearnMoreClick = () => {
+    setIsExpanded(!isExpanded);
+  }
+
+  const onExpand = () => {
+    drawerRef.current && drawerRef.current.focus();
+  };
+
+  const panelContent = (
+    <DrawerPanelContent isResizable defaultSize={'500px'} minSize={'150px'}>
+      <DrawerHead>
+        <TextContent>
+          <Title headingLevel="h1">Bug CI Impact</Title>
+          <span>
+            This page aims to help you observe the impact of the bugs that are affecting your team's Openshift CI prow jobs. <br />You can add, update, or delete them. To add a new entry, you need to point out the Jira Key of the bug and the associated error message.
+          </span>
+          <Title headingLevel="h1">How the frequency/impact is measured?</Title>
+          <span>
+            To calculate the impact of each bug, in the date time range selected, Quality Dashboard will search for all the team's OpenShift CI prow jobs and verify in how many of them the bug's error message is present.
+            <br /> Note that the only the OpenShift CI prow jobs reports that matches regex &apos;(j?unit|e2e)-?[0-9a-z]+\.xml&apos; are saved on the DB.
+          </span>
+        </TextContent>
+        <DrawerActions>
+          <DrawerCloseButton onClick={onCloseClick} />
+        </DrawerActions>
+      </DrawerHead>
+    </DrawerPanelContent>
+  );
+
   return (
     <ModalContext.Provider value={defaultModalContext}>
       <React.Fragment>
         {/* page title bar */}
-        <Header info="Observe the impact of the RHTAPBUGS that are affecting CI."></Header>
+        <Header info="Observe the impact of the bugs that are affecting your team's Openshift CI prow jobs."></Header>
         <PageSection variant={PageSectionVariants.light}>
           <Title headingLevel="h3" size={TitleSizes['2xl']}>
-            RHTAPBUGS Impact on CI
+            Bug CI Impact
             <Button
               onClick={() => navigator.clipboard.writeText(window.location.href)}
               variant="link"
@@ -154,49 +196,54 @@ let CiFailures = () => {
               variant={ButtonVariant.secondary}
               onClick={onClick}
             >
-              <PlusIcon /> &nbsp; Add a RHTAPBUG
+              <PlusIcon /> &nbsp; Add a bug
             </Button>
           </Title>
         </PageSection>
         {/* main content  */}
-        <PageSection>
-          {/* the following toolbar will contain the form (dropdowns and button) to request data to the server */}
-          <Grid hasGutter>
-            <FormModal></FormModal>
+        <Drawer isExpanded={isExpanded} onExpand={onExpand}>
+          <DrawerContent panelContent={panelContent}>
+            <PageSection>
+              {/* the following toolbar will contain the form (dropdowns and button) to request data to the server */}
+              <Grid hasGutter>
+                <FormModal></FormModal>
 
 
-            {/* this section will show statistics and details about CiFailures metric */}
-            {loadingState && <div style={{ width: '100%', textAlign: "center" }}>
-              <Spinner isSVG diameter="80px" aria-label="Contents of the custom size example" style={{ margin: "100px auto" }} />
-            </div>
-            }
-            {!loadingState &&
-              (
-                <GridItem>
-                  <Card>
-                    <Flex>
-                      <FlexItem>
-                        <CardTitle>
-                          RHTAPBUGS Impact on CI Overview
-                        </CardTitle>
-                      </FlexItem>
-                      <FlexItem align={{ default: 'alignRight' }} style={{ marginRight: "25px" }}>
-                        <DateTimeRangePicker
-                          startDate={start}
-                          endDate={end}
-                          handleChange={(event, from, to) => handleChange(event, from, to)}
-                        ></DateTimeRangePicker>
-                      </FlexItem>
-                    </Flex>
-                    <CardBody>
-                      <ComposableTable failures={failures} modal={modalContext}></ComposableTable>
-                    </CardBody>
-                  </Card>
-                </GridItem>
-              )
-            }
-          </Grid>
-          {/* {isInvalid && !loadingState && (
+                {/* this section will show statistics and details about CiFailures metric */}
+                {loadingState && <div style={{ width: '100%', textAlign: "center" }}>
+                  <Spinner isSVG diameter="80px" aria-label="Contents of the custom size example" style={{ margin: "100px auto" }} />
+                </div>
+                }
+                {!loadingState &&
+                  (
+                    <GridItem>
+                      <Card>
+                        <Flex>
+                          <FlexItem>
+                            <CardTitle>
+                              Bug CI Impact Overview
+                              <Button onClick={onLearnMoreClick} variant="link" icon={<OpenDrawerRightIcon />} iconPosition="right">
+                                Learn more
+                              </Button>
+                            </CardTitle>
+                          </FlexItem>
+                          <FlexItem align={{ default: 'alignRight' }} style={{ marginRight: "25px" }}>
+                            <DateTimeRangePicker
+                              startDate={start}
+                              endDate={end}
+                              handleChange={(event, from, to) => handleChange(event, from, to)}
+                            ></DateTimeRangePicker>
+                          </FlexItem>
+                        </Flex>
+                        <CardBody>
+                          <ComposableTable failures={failures} modal={modalContext}></ComposableTable>
+                        </CardBody>
+                      </Card>
+                    </GridItem>
+                  )
+                }
+              </Grid>
+              {/* {isInvalid && !loadingState && (
             <EmptyState variant={EmptyStateVariant.xl}>
               <EmptyStateIcon icon={ExclamationCircleIcon} />
               <Title headingLevel="h1" size="lg">
@@ -205,7 +252,9 @@ let CiFailures = () => {
             </EmptyState>
           )} */}
 
-        </PageSection>
+            </PageSection>
+          </DrawerContent>
+        </Drawer>
       </React.Fragment>
     </ModalContext.Provider>
   );

--- a/frontend/src/app/CiFailures/CreateFailure.tsx
+++ b/frontend/src/app/CiFailures/CreateFailure.tsx
@@ -1,4 +1,4 @@
-import { createFailure } from '@app/utils/APIService';
+import { bugExists, createFailure } from '@app/utils/APIService';
 import {
   Button,
   Form,
@@ -70,7 +70,7 @@ export const FormModal = () => {
   const [jiraKeyValidated, setJiraKeyValidated] = React.useState<validate>('error');
   const [msgValidated, setMsgValidated] = React.useState<validate>('error');
   const params = new URLSearchParams(window.location.search);
-
+  const [helperText, setHelperText] = React.useState('Enter your age to continue');
   const { store } = useContext(ReactReduxContext);
   const state = store.getState();
 
@@ -80,9 +80,11 @@ export const FormModal = () => {
     setJiraKeyValidated('error');
     setJiraKeyValue(value);
     if (value != "" && value != undefined) {
-      setJiraKeyValidated('success');
-    } else {
-      setJiraKeyValidated('error');
+      bugExists(value, state.teams.Team).then(res => {
+        if (res != undefined && res.code == 200) {
+          setJiraKeyValidated('success');
+        }
+      })
     }
   };
 
@@ -146,10 +148,10 @@ export const FormModal = () => {
     <React.Fragment>
       <Modal
         variant={ModalVariant.medium}
-        title={!modalContext.isEdit.value ? 'Add a RHTAPBUG' : 'Update'}
+        title={!modalContext.isEdit.value ? 'Add a bug' : 'Update'}
         description={
           !modalContext.isEdit.value
-            ? 'Track the impact of a RHTAPBUG'
+            ? 'Track the impact of a bug'
             : ''
         }
         isOpen={modalContext.isModalOpen.value}
@@ -174,7 +176,7 @@ export const FormModal = () => {
           <FormGroup
             label="Jira Key"
             labelIcon={
-              <Popover headerContent={<div></div>} bodyContent={<div>Add a Jira Key that refers to a ci-fail issue.</div>}>
+              <Popover headerContent={<div></div>} bodyContent={<div>Add a Jira Key that refers to a bug affecting CI. Note that the Jira Key should belong to your team's Jira Projects.</div>}>
                 <button
                   type="button"
                   aria-label="More info for e-mail field"

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -80,7 +80,7 @@ const routes: AppRouteConfig[] = [
     ],
   },
   {
-    label: 'Plugins',
+    label: 'Metrics',
     routes: [
       {
         component: GitHub,
@@ -114,9 +114,9 @@ const routes: AppRouteConfig[] = [
         exact: true,
         isAsync: true,
         isProtected: true,
-        label: 'RHTAPBUGS Impact on CI',
+        label: 'Bug CI Impact',
         path: '/home/rhtapbugs-impact',
-        title: 'RHTAPBUGS Impact on CI | Quality Studio',
+        title: 'Bug CI Impact | Quality Studio',
       },
       {
         label: 'OpenShift CI',

--- a/frontend/src/app/utils/Header.tsx
+++ b/frontend/src/app/utils/Header.tsx
@@ -15,7 +15,7 @@ export const Header = (props) => {
         >
             <TextContent style={{ color: "white", display: "inline" }}>
                 <div style={{ float: "left", }}>
-                    <Text component="h2">Get Started with Red Hat Quality Studio's Plugins</Text>
+                    <Text component="h2">Get Started with Red Hat Quality Studio's Metrics</Text>
                     <Text component="p">{info}</Text>
                 </div>
             </TextContent>

--- a/frontend/src/app/utils/utils.ts
+++ b/frontend/src/app/utils/utils.ts
@@ -66,7 +66,7 @@ export function validateRepositoryParams(repos, repository, organization) {
 
 // validateParam validates if 'param' exists in 'params'
 export function validateParam(params, param) {
-  if (params.find((p) => p == param)) {
+  if (params.find((p) => p.team_name == param)) {
     return true;
   }
   return false;


### PR DESCRIPTION
# Description
Currently, the RHTAPBUGS Impact on CI page is "designed" only for the RHTAPBUGS project (of the KONFLUX team). This page should be designed for any team.

- Changed `Plugins` to `Metrics`
- Changed the `RHTAPBUGS Impact on CI` page to `Bug CI Impact`
- Added some tips and explanations regarding what the page does and what means ('Learn more' button).
- Added validation of the Jira Key when the user adds a new entry.

## Issue ticket number and link
[AD-175](https://issues.redhat.com/browse/AD-175)