### PR TITLE
AD-182: Update default team in user settings when deleting the default team

### DIFF
--- a/frontend/src/app/Reports/Reports.tsx
+++ b/frontend/src/app/Reports/Reports.tsx
@@ -527,7 +527,7 @@ let Reports = () => {
                     placeholderText="Select a repository"
                   >
                     {repositories.map((value, index) => (
-                      <SelectOption key={index} value={index} description={value.Repository.Name + "/" + value.Repository.Owner.Login} isDisabled={value.isPlaceholder}>{getRepoNameFormatted(value.Repository.Name)}</SelectOption>
+                      <SelectOption key={index} value={index} description={value.Repository.Owner.Login + "/" +value.Repository.Name} isDisabled={value.isPlaceholder}>{getRepoNameFormatted(value.Repository.Name)}</SelectOption>
                     ))}
                   </Select>
                 </ToolbarItem>


### PR DESCRIPTION
# Description
If there is an edge case, where the default team is deleted, we need to update the default team in user settings to be "n/a", until the user configures it again.

## Issue ticket number and link
[AD-182](https://issues.redhat.com/browse/AD-182)