### PR TITLE
AD-183 - add message validation when adding a GitHub Repository

### DIFF
--- a/backend/api/server/router/repositories/repositories_route.go
+++ b/backend/api/server/router/repositories/repositories_route.go
@@ -40,7 +40,8 @@ func NewRouter(s storage.Storage) router.Router {
 		router.NewPostRoute("/repositories/create", r.createRepositoryHandler),
 		router.NewDeleteRoute("/repositories/delete", r.deleteRepositoryHandler),
 		router.NewGetRoute("/prs/get", r.getPullRequestsFromRepo),
-		router.NewGetRoute("/repositories/verify", r.checkGithubRepository),
+		router.NewGetRoute("/repositories/verify", r.checkGithubRepositoryUrl),
+		router.NewGetRoute("/repositories/exists", r.checkGithubRepositoryExists),
 	}
 
 	return r

--- a/backend/pkg/storage/ent/client/repository.go
+++ b/backend/pkg/storage/ent/client/repository.go
@@ -102,7 +102,7 @@ func (d *Database) DeleteRepository(repositoryName string, gitOrganizationName s
 	return nil
 }
 
-// ListPasswords extracts an array of repositories from the database.
+// ListAllRepositories extracts an array of repositories from the database.
 func (d *Database) ListAllRepositories() ([]*db.Repository, error) {
 	repositories, err := d.client.Repository.Query().All(context.Background())
 	if err != nil {

--- a/frontend/src/app/Github/CreateRepository.tsx
+++ b/frontend/src/app/Github/CreateRepository.tsx
@@ -17,7 +17,7 @@ import { teamIsNotEmpty } from '@app/utils/utils';
 import { useHistory } from 'react-router-dom';
 import { ReactReduxContext } from 'react-redux';
 import { formatDate, getRangeDates } from '@app/Reports/utils';
-import { githubRegExp } from '@app/Teams/TeamsOnboarding';
+import { ghRegex, githubRegExp } from '@app/Teams/TeamsOnboarding';
 
 interface IModalContext {
   isModalOpen: IModalContextMember;
@@ -191,7 +191,7 @@ export const FormModal: React.FunctionComponent = () => {
         })
       }
     } else {
-      setHelperText('Must match the regex `https: \/\/github\.com\/[a-zA-Z0-9-_.]+\/[a-zA-Z0-9-_.]+`')
+      setHelperText('Must match the regex `' + ghRegex +'`')
     }
   };
 

--- a/frontend/src/app/Github/Github.tsx
+++ b/frontend/src/app/Github/Github.tsx
@@ -199,6 +199,7 @@ let GitHub = () => {
 
   return (
     <ModalContext.Provider value={defaultModalContext}>
+      <FormModal></FormModal>
       <React.Fragment>
         {/* page title bar */}
         <Header info="Analyze the GitHub metrics overview of all your team's repositories."></Header>
@@ -226,9 +227,6 @@ let GitHub = () => {
         <PageSection>
           {/* the following toolbar will contain the form (dropdowns and button) to request data to the server */}
           <Grid hasGutter>
-            <FormModal></FormModal>
-
-
             {/* this section will show statistics and details about GitHub metric */}
             {loadingState && <div style={{ width: '100%', textAlign: "center" }}>
               <Spinner isSVG diameter="80px" aria-label="Contents of the custom size example" style={{ margin: "100px auto" }} />

--- a/frontend/src/app/Teams/TeamsOnboarding.tsx
+++ b/frontend/src/app/Teams/TeamsOnboarding.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useContext, useEffect } from 'react';
-import { createTeam, createRepository, listJiraProjects, checkGithubRepository } from "@app/utils/APIService";
+import { createTeam, createRepository, listJiraProjects, checkGithubRepositoryUrl, checkGithubRepositoryExists } from "@app/utils/APIService";
 import {
   Wizard, PageSection, PageSectionVariants,
   TextInput, FormGroup, Form, TextArea,
@@ -43,6 +43,7 @@ export const TeamsWizard = () => {
   const [githubUrl, setGithubUrl] = useState<string>("");
   type validate = 'success' | 'warning' | 'error' | 'default';
   const [githubUrlValidated, setGithubUrlValidated] = React.useState<validate>();
+  const [helperText, setHelperText] = useState<string>("Enter a GitHub Repository URL");
 
   const onSubmit = async () => {
     // Create a team
@@ -159,24 +160,40 @@ export const TeamsWizard = () => {
   )
 
   const handleGithub = async (value: string) => {
+    setHelperText('')
     setGithubUrl(value);
     setGithubUrlValidated('error');
 
-    // check that matchesgithubRegExp
-    if (githubRegExp.test(value)) {
-      // check that gh repo exists
-      const repo = value.replace("https://github.com/", "").split("/")
 
-      await checkGithubRepository(repo[0], repo[1]).then((data: any) => {
-        if (data != undefined && data.code == 200) {
-          setGithubUrlValidated('success');
-          // save repo and org
-          setNewOrgName(repo[0]);
-          setNewRepoName(repo[1]);
-        }
-      })
+    if (value == "") {
+      setGithubUrlValidated('success');
     } else {
-      setGithubUrlValidated('error');
+      // check that matches githubRegExp
+      if (githubRegExp.test(value)) {
+        const repo = value.replace("https://github.com/", "").split("/")
+
+
+        // check that gh repo was not already added
+        const resp = await checkGithubRepositoryExists(repo[0], repo[1])
+        if (resp != undefined && resp.code == 200) {
+          const team = resp.data as string
+          setHelperText('Already exists in ' + team + ' team')
+        } else {
+          await checkGithubRepositoryUrl(repo[0], repo[1]).then((data: any) => {
+            if (data != undefined && data.code == 200) {
+              setGithubUrlValidated('success');
+              // save repo and org
+              setNewOrgName(repo[0]);
+              setNewRepoName(repo[1]);
+              setHelperText('')
+            } else {
+              setHelperText('Something went wrong. Probably URL is incorrect.')
+            }
+          })
+        }
+      } else {
+        setHelperText('Must match the regex `https: \/\/github\.com\/[a-zA-Z0-9-_.]+\/[a-zA-Z0-9-_.]+`')
+      }
     }
   };
 
@@ -184,7 +201,7 @@ export const TeamsWizard = () => {
     <div className={'pf-u-m-lg'} >
       <Title style={{ marginBottom: '20px' }} headingLevel="h6" size="xl">Optionally: add a GitHub repository to your team</Title>
       <Form>
-        <FormGroup label="GitHub Repository URL" fieldId="repo-name">
+        <FormGroup label="GitHub Repository URL" fieldId="repo-name" helperText={helperText}>
           <TextInput validated={githubUrlValidated} value={githubUrl} type="text" onChange={handleGithub} aria-label="text input example" placeholder="Add a GitHub repository" />
         </FormGroup>
       </Form>
@@ -244,7 +261,7 @@ export const TeamsWizard = () => {
 
   const steps = [
     { id: 'team', name: 'Team Name', component: TeamData, enableNext: ValidateTeam() },
-    { id: 'repo', name: 'Add a GitHub repository', component: AddRepo, canJumpTo: ValidateTeam(), enableNext: ValidateRepoAndOrg() },
+    { id: 'repo', name: 'Add a GitHub repository', component: AddRepo, canJumpTo: ValidateTeam(), enableNext: githubUrlValidated != 'error' },
     { id: 'jira', name: 'Jira Projects', component: JiraProjects({ onChange: jiraOnChange, teamJiraKeys: "" }), canJumpTo: ValidateTeam(), enableNext: ValidateTeam() },
     {
       id: 'review',

--- a/frontend/src/app/Teams/TeamsOnboarding.tsx
+++ b/frontend/src/app/Teams/TeamsOnboarding.tsx
@@ -19,7 +19,8 @@ export interface AlertInfo {
   key: string;
 }
 
-export const githubRegExp = new RegExp('https:\/\/github\.com\/[a-zA-Z0-9-_.]+\/[a-zA-Z0-9-_.]+')
+export const ghRegex = 'https:\/\/github\.com\/[a-zA-Z0-9-_.]+\/[a-zA-Z0-9-_.]+'
+export const githubRegExp = new RegExp(ghRegex)
 
 export const TeamsWizard = () => {
   const { store } = useContext(ReactReduxContext);
@@ -192,7 +193,7 @@ export const TeamsWizard = () => {
           })
         }
       } else {
-        setHelperText('Must match the regex `https: \/\/github\.com\/[a-zA-Z0-9-_.]+\/[a-zA-Z0-9-_.]+`')
+        setHelperText('Must match the regex `' + ghRegex + '`')
       }
     }
   };

--- a/frontend/src/app/utils/APIService.ts
+++ b/frontend/src/app/utils/APIService.ts
@@ -27,8 +27,10 @@ async function getVersion() {
     await axios
       .get(uri)
       .then((res: AxiosResponse) => {
-        result.code = res.status;
-        result.data = res.data;
+        if (res != undefined) {
+          result.code = res.status;
+          result.data = res.data;
+        }
       })
       .catch((err) => {
         result.code = err.response.status;
@@ -48,8 +50,10 @@ async function getJiras() {
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -73,8 +77,10 @@ async function getJirasResolutionTime(priority: string, team: string, rangeDateT
       end: end_date,
     })
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -90,8 +96,10 @@ async function listJiraProjects() {
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -115,8 +123,10 @@ async function getJirasOpen(priority: string, team: string, rangeDateTime: Date[
       end: end_date,
     })
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -141,12 +151,15 @@ async function getRepositories(perPage = 50, team: string) {
       },
     })
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.all = res.data;
-      if (res.data.length >= REPOS_IN_PAGE) {
-        result.data = _.chunk(res.data, REPOS_IN_PAGE);
-      } else {
-        result.data = _.chunk(res.data, res.data.length);
+      if (res != undefined) {
+
+        result.code = res.status;
+        result.all = res.data;
+        if (res.data.length >= REPOS_IN_PAGE) {
+          result.data = _.chunk(res.data, REPOS_IN_PAGE);
+        } else {
+          result.data = _.chunk(res.data, res.data.length);
+        }
       }
     })
     .catch((err) => {
@@ -176,8 +189,10 @@ async function getAllRepositoriesWithOrgs(team: string, openshift: boolean, rang
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -216,8 +231,10 @@ async function getWorkflowByRepositoryName(repositoryName: string) {
       },
     })
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -238,8 +255,10 @@ async function createRepository(data = {}) {
       data: { ...data },
     })
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -262,8 +281,10 @@ async function getLatestProwJob(repoName: string, repoOrg: string, jobType: stri
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -297,8 +318,10 @@ async function getProwJobStatistics(repoName: string, repoOrg: string, jobType: 
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -321,8 +344,10 @@ async function getTeams() {
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -342,8 +367,10 @@ async function createTeam(data = {}) {
       data: { ...data },
     })
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -362,8 +389,10 @@ async function getJobTypes(repoName: string, repoOrg: string) {
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -386,8 +415,10 @@ async function getJobNamesAndTypes(repoName: string, repoOrg: string) {
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -415,8 +446,10 @@ async function deleteInApi(data = {}, subPath: string) {
       data: data,
     })
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -438,8 +471,10 @@ async function updateTeam(data = {}) {
       timeout: 120000,
     })
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -458,8 +493,10 @@ async function checkDbConnection() {
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -487,8 +524,10 @@ async function getPullRequests(repoName: string, repoOrg: string, rangeDateTime:
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -514,8 +553,10 @@ async function getProwJobs(repoName: string, repoOrg: string, rangeDateTime: Dat
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -535,8 +576,10 @@ async function listBugsAffectingCI(team: string) {
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -559,8 +602,10 @@ async function getFailures(team: string, rangeDateTime: Date[]) {
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.statusCode;
@@ -585,8 +630,10 @@ async function createFailure(team: string, jiraKey: string, errorMessage: string
       },
     })
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -603,8 +650,10 @@ async function bugExists(jiraKey: string, teamName: string) {
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.status;
@@ -630,8 +679,10 @@ async function getBugSLIs(team: string) {
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -661,8 +712,10 @@ async function getRepositoriesWithJobs(team: string) {
       },
     })
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -691,8 +744,10 @@ async function getFlakyData(team: string, job: string, repo: string, rangeDateTi
       },
     })
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -721,8 +776,10 @@ async function getGlobalImpactData(team: string, job: string, repo: string, rang
       },
     })
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -743,8 +800,10 @@ async function listTeamRepos(team: string) {
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -779,8 +838,10 @@ async function getProwJobMetricsDaily(repoName: string, repoOrg: string, jobType
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -810,8 +871,10 @@ async function createUser(userEmail: string, userConfig: string) {
       },
     })
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -829,8 +892,10 @@ async function listUsers() {
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -852,8 +917,10 @@ async function getUser(userEmail: string) {
       },
     })
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -862,7 +929,7 @@ async function getUser(userEmail: string) {
   return result;
 }
 
-async function checkGithubRepository(repoOrg: string, repoName: string) {
+async function checkGithubRepositoryUrl(repoOrg: string, repoName: string) {
   const result: ApiResponse = { code: 0, data: {} };
   const subPath = '/api/quality/repositories/verify?repository_name=' +
     repoName +
@@ -873,8 +940,34 @@ async function checkGithubRepository(repoOrg: string, repoName: string) {
   await axios
     .get(uri)
     .then((res: AxiosResponse) => {
-      result.code = res.status;
-      result.data = res.data;
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
+    })
+    .catch((err) => {
+      result.code = err.response.status;
+      result.data = err.response.data;
+    });
+
+  return result;
+}
+
+async function checkGithubRepositoryExists(repoOrg: string, repoName: string) {
+  const result: ApiResponse = { code: 0, data: {} };
+  const subPath = '/api/quality/repositories/exists?repository_name=' +
+    repoName +
+    '&git_organization=' +
+    repoOrg
+  const uri = API_URL + subPath;
+
+  await axios
+    .get(uri)
+    .then((res: AxiosResponse) => {
+      if (res != undefined) {
+        result.code = res.status;
+        result.data = res.data;
+      }
     })
     .catch((err) => {
       result.code = err.response.status;
@@ -918,5 +1011,6 @@ export {
   createUser,
   listUsers,
   getUser,
-  checkGithubRepository
+  checkGithubRepositoryUrl,
+  checkGithubRepositoryExists
 };


### PR DESCRIPTION
# Description
Currently, when adding a repository, the form hangs when the repository that's being added already exists. We should inform the user that the repo already exists, is incorrect, or is not match the GH URL regex

## Issue ticket number and link
[AD-183](https://issues.redhat.com/browse/AD-183)