### PR TITLE
fix lint error

### DIFF
--- a/backend/pkg/utils/utils.go
+++ b/backend/pkg/utils/utils.go
@@ -96,6 +96,9 @@ func RoundTo(n float64, decimals uint32) float64 {
 
 func GenerateRandomString(length int) string {
 	bytes := make([]byte, (length+1)/2)
-	rand.Read(bytes)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		panic("Error generating random string")
+	}
 	return base64.URLEncoding.EncodeToString(bytes)[:length]
 }


### PR DESCRIPTION
Backend linter fails with:
```
pkg/utils/utils.go:99:11: Error return value of `rand.Read` is not checked (errcheck)
	rand.Read(bytes)
```