### PR TITLE
change "Failed to get pr number from" log from Warn to Debug

### DIFF
--- a/backend/api/server/prow_rotate.go
+++ b/backend/api/server/prow_rotate.go
@@ -262,7 +262,7 @@ func (s *Server) ErrorsUpdateInProwJobs() {
 					suites = s.cfg.GCS.GetJobJunitContent("redhat-appstudio", "infra-deployments", prNumber,
 						pj.JobID, pj.JobType, pj.JobName, JunitRegexpSearch)
 				} else {
-					s.cfg.Logger.Sugar().Warnf("Failed to get pr number from ", pj.JobURL)
+					s.cfg.Logger.Sugar().Debug("Failed to get pr number from ", pj.JobURL)
 				}
 			}
 


### PR DESCRIPTION
change "Failed to get pr number from" log from Warn to Debug to avoid a lot of warnings in the logs