### PR TITLE
fix: infra-deployments update script

### DIFF
--- a/.tekton/push-backend.yaml
+++ b/.tekton/push-backend.yaml
@@ -16,9 +16,6 @@ spec:
       value: "quay.io/redhat-appstudio/quality-dashboard-backend:{{revision}}"
     - name: path-context
       value: "backend"
-    - name: infra-deployment-update-script
-      value: |
-        sed -i -e 's|\(https://github.com/redhat-appstudio/quality-dashboard/backend/deploy/base?ref=\).*|\1{{ revision }}|' -e 's|\(newTag: \).*|\1{{ revision }}|' components/quality-dashboard/base/backend/kustomization.yaml
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest

--- a/.tekton/push-frontend.yaml
+++ b/.tekton/push-frontend.yaml
@@ -18,7 +18,9 @@ spec:
       value: "frontend"
     - name: infra-deployment-update-script
       value: |
-        sed -i -e 's|\(https://github.com/redhat-appstudio/quality-dashboard/frontend/deploy/base?ref=\).*|\1{{ revision }}|' -e 's|\(newTag: \).*|\1{{ revision }}|' components/quality-dashboard/base/frontend/kustomization.yaml
+        sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/quality-dashboard/base/backend/kustomization.yaml
+        sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/quality-dashboard/base/dex/kustomization.yaml
+        sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/quality-dashboard/base/frontend/kustomization.yaml
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest


### PR DESCRIPTION
The old version of the script was replacing the frontend/backend manifests (depending on which component made if first to infra-deployments PR) and the resulted PR contained only the change to a **single component** (backend or frontend)

![Screenshot 2024-04-19 at 18 18 44](https://github.com/redhat-appstudio/quality-dashboard/assets/4881144/ae84e149-8a99-46ea-93d2-a589387d3ccf)

This PR fixes it by keeping the `infra-deployment-update-script` only in a single component (frontend) and the script updates git revision (git ref and image tag) for all 3 components (backend, dex, frontend) at once